### PR TITLE
Constrain Go toolchain updates to 1.25.x patch releases

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -15,6 +15,11 @@
       "description": "Group Go module updates together",
       "matchManagers": ["gomod"],
       "groupName": "go-modules"
+    },
+    {
+      "description": "Pin Go toolchain to 1.25.x — allow patch updates but not minor version bumps",
+      "matchDatasources": ["golang-version"],
+      "allowedVersions": "< 1.26"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Added a Renovate configuration rule to pin Go toolchain versions to the 1.25.x release series, preventing automatic upgrades to Go 1.26 and later minor versions while still allowing patch-level updates.

## Changes
- Added a new Renovate grouping rule that targets `golang-version` datasource
- Configured `allowedVersions` constraint to `< 1.26`, ensuring only Go 1.25.x versions are considered for updates
- This prevents unintended minor version bumps while maintaining access to security patches and bug fixes within the 1.25 series

## Details
The new rule uses Renovate's version constraint syntax to maintain stability by locking the Go toolchain to a specific minor version. This is useful for projects that want to control when major toolchain upgrades occur while still receiving patch updates automatically.

https://claude.ai/code/session_011GkyjTnCPyXTUgtYL5fQiK