### PR TITLE
fix(renovate): track the Go patch release in go.mod, not just the docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ renovate.json             Renovate dependency auto-update config
 - Go 1.25.x. The exact patch release lives in the `toolchain` directive in
   `go.mod`; CI installs it via `go-version-file: go.mod`, and Renovate bumps it.
   The `go` directive stays at `1.25` as the minimum for consumers of the package.
-- golangci-lint v2.11.4 (pinned in CI)
+- golangci-lint. The version is pinned in `.github/workflows/ci.yaml`.
 
 ### Installing Go
 
@@ -293,7 +293,7 @@ See `docs/test-coverage-analysis.md` for detailed coverage data and test invento
 
 GitHub Actions workflow at `.github/workflows/ci.yaml` runs:
 - **Test**: `go test -v -count=1 -race -coverprofile=coverage.out` (uploads coverage artifact)
-- **Lint**: golangci-lint v2.10.1 via `golangci-lint-action`
+- **Lint**: golangci-lint via `golangci-lint-action`
 - **Vet**: `go vet`, `go mod tidy` check, `govulncheck`
 - **Format**: `gofmt -l`, `goimports -l` (fail if any files are unformatted)
 - **Build**: Cross-compile linux/darwin/windows x amd64/arm64 with ldflags (depends on all other jobs)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,8 +53,10 @@ renovate.json             Renovate dependency auto-update config
 
 ### Requirements
 
-- Go 1.25.x (pinned in CI: 1.25.7)
-- golangci-lint v2.10.1+
+- Go 1.25.x. The exact patch release lives in the `toolchain` directive in
+  `go.mod`; CI installs it via `go-version-file: go.mod`, and Renovate bumps it.
+  The `go` directive stays at `1.25` as the minimum for consumers of the package.
+- golangci-lint v2.11.4 (pinned in CI)
 
 ### Installing Go
 
@@ -63,13 +65,13 @@ due to DNS/network restrictions), install manually:
 
 ```bash
 # Download (linux/amd64 — adjust for your platform)
-curl -fSL -o /tmp/go1.25.8.linux-amd64.tar.gz "https://go.dev/dl/go1.25.8.linux-amd64.tar.gz"
+curl -fSL -o /tmp/go1.25.13.linux-amd64.tar.gz "https://go.dev/dl/go1.25.13.linux-amd64.tar.gz"
 
 # Install (removes any previous Go installation in /usr/local/go)
-rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go1.25.8.linux-amd64.tar.gz
+rm -rf /usr/local/go && tar -C /usr/local -xzf /tmp/go1.25.13.linux-amd64.tar.gz
 
 # Verify
-go version   # should print "go version go1.25.8 linux/amd64"
+go version   # should print "go version go1.25.13 linux/amd64"
 ```
 
 Ensure `/usr/local/go/bin` is in your `PATH`.

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/yesdevnull/trenchcoat
 
 go 1.25
 
+toolchain go1.25.13
+
 require (
 	github.com/bmatcuk/doublestar/v4 v4.10.0
 	github.com/fsnotify/fsnotify v1.9.0

--- a/renovate.json
+++ b/renovate.json
@@ -30,21 +30,25 @@
       "groupName": "github-actions"
     },
     {
-      "description": "Group Go module updates together",
+      "description": "Group Go module dependency updates together. Scoped to the 'go' datasource so it does not capture the go/toolchain directives, which use 'golang-version' and are grouped separately below.",
       "matchManagers": [
         "gomod"
+      ],
+      "matchDatasources": [
+        "go"
       ],
       "groupName": "go-modules"
     },
     {
-      "description": "Pin Go toolchain to 1.25.x — allow patch updates but not minor version bumps",
+      "description": "Pin the Go toolchain to 1.25.x — allow patch updates but not minor version bumps. Covers both the go.mod toolchain directive and the Go version references in CLAUDE.md, which share depName 'go' on the golang-version datasource, and groups them so a Go patch release updates code and docs in a single PR.",
       "matchDatasources": [
         "golang-version"
       ],
       "matchPackageNames": [
         "go"
       ],
-      "allowedVersions": "/^1\\.25(?:$|\\.)/"
+      "allowedVersions": "/^1\\.25(?:$|\\.)/",
+      "groupName": "go-version"
     }
   ]
 }


### PR DESCRIPTION
Closes #32.

## The problem

#32 bumped Go 1.25.8 → 1.25.13 and touched only `CLAUDE.md`. That is all it could touch: the only thing in the repo naming a Go patch version was a `customManager` scoped to `/^CLAUDE\.md$/`. `go.mod` had `go 1.25` and no `toolchain` directive, so nothing in the actual build tracked the patch release.

## The fix

Add `toolchain go1.25.13` to `go.mod`.

- Renovate's `gomod` manager proposes `toolchain` updates **by default** (unlike the `go` directive, which needs an explicit `rangeStrategy: "bump"` rule), so no extra manager config is needed.
- CI picks it up through the existing `go-version-file: go.mod`. actions/setup-go v6 resolves the `toolchain` directive in preference to the `go` directive, so CI now installs exactly 1.25.13 rather than whatever the latest 1.25.x happens to be.

The `go` directive deliberately stays at `1.25`. It sets the minimum language version imposed on anyone importing the package, and a `toolchain` directive in a dependency is ignored by the importing module — so pinning the patch there would raise every consumer's floor to 1.25.13 for no benefit to this repo.

Renovate config changes:

- Group the toolchain directive with the CLAUDE.md references, so a Go patch release produces **one** PR covering code and docs rather than two. Both extract as `depName: 'go'` on the `golang-version` datasource, so the existing `1.25.x` `allowedVersions` constraint already governs the toolchain directive — the pin is preserved.
- Scope the `go-modules` group to the `go` datasource so it cannot swallow the toolchain dependency. Both rules previously matched it and the outcome depended on `packageRules` ordering; they are now disjoint.

Also corrected two stale lines in CLAUDE.md, both wrong independently of this change: CI has not pinned Go 1.25.7 since it moved to `go-version-file`, and golangci-lint is pinned at v2.11.4, not v2.10.1.

## On go.sum

`go.sum` is deliberately not modified. It holds module checksums; neither the `go` nor the `toolchain` directive contributes an entry. Verified by adding the directive and running `go mod tidy` — `go.sum` came back byte-identical.

## Verification

- `npx --package renovate@latest renovate-config-validator renovate.json` → `Config validated successfully`. Worth noting: an older cached validator rejects the **pre-existing** `managerFilePatterns` field; that is a stale-validator artefact, since the current schema at `docs.renovatebot.com/renovate-schema.json` lists `managerFilePatterns` for `customManagers` and no longer has `fileMatch`.
- Renovate behaviour for both directives confirmed against `lib/modules/manager/gomod/` in the Renovate source, not inferred.
- setup-go's toolchain precedence confirmed against its v6 breaking-changes documentation.
- `go build ./...` and `go test ./...` pass; `go.sum` unchanged.

One behaviour worth being explicit about: `toolchain` is a floor, not a ceiling. A developer with a newer Go keeps using it locally — verified here, where `go env GOVERSION` still reports go1.26.6 with the directive in place. It pins CI, not local machines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1EPocipfXepFxJFoRS9h9
