### PR TITLE
docs: document response templating and complete the validation rules

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Available fields and methods:
 |------------------|------------------------------------------------------|
 | `.Method`        | Request method                                       |
 | `.Path`          | Request URL path                                     |
-| `.Body`          | Request body (capped at `maxRecordBodySize`)         |
+| `.Body`          | Request body (capped at 1 MiB, `maxRecordBodySize`)  |
 | `.Query "page"`  | First value of a query parameter, `""` if absent     |
 | `.Segment 3`     | Nth path segment, 0-indexed from root, `""` if absent|
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,8 @@ internal/
     query.go              QueryField YAML/JSON unmarshalling
   config/                 Viper-based config file loading
     config.go             Config discovery: --config > .trenchcoat.yaml > ~/.config/trenchcoat/config.yaml
+  httputil/               Shared HTTP helpers
+    body.go               ReconstitutedBody: replay a consumed body for downstream readers
   matcher/                Request matching engine (exact, glob, regex URI)
     matcher.go            Match logic, precedence scoring, sequence state
   proxy/                  Proxy capture server
@@ -44,6 +46,7 @@ docs/
   test-coverage-analysis.md  Coverage report and test inventory
 trenchcoat.go             Public API package for Go test integration
 trenchcoat_test.go        Public API tests
+coatfile.schema.json      JSON Schema for coat files (hand-maintained — see Validation Rules)
 .github/workflows/ci.yaml  CI pipeline (test, lint, vet, format, build)
 .goreleaser.yaml          GoReleaser config for cross-platform releases
 renovate.json             Renovate dependency auto-update config
@@ -189,6 +192,24 @@ coats:
     sequence: cycle                  # cycle (default) or once
 ```
 
+### Response Body Templating
+
+Response bodies containing `{{` are rendered as a Go `text/template` with request
+context, after `body_file` resolution — so `body_file` contents are templated too.
+Available fields and methods:
+
+| Field            | Meaning                                              |
+|------------------|------------------------------------------------------|
+| `.Method`        | Request method                                       |
+| `.Path`          | Request URL path                                     |
+| `.Body`          | Request body (capped at `maxRecordBodySize`)         |
+| `.Query "page"`  | First value of a query parameter, `""` if absent     |
+| `.Segment 3`     | Nth path segment, 0-indexed from root, `""` if absent|
+
+A body that legitimately contains `{{` will be treated as a template. Parse
+failures return the body unrendered and silently; execution failures log a
+warning and return the body unrendered.
+
 ### URI Matching Modes
 
 | Mode  | Syntax            | Example                    |
@@ -206,6 +227,14 @@ coats:
 4. Regex URI (file-definition order)
 5. `method: ANY` ranks below method-specific at same specificity
 
+Specificity is the count of qualifiers on the request: headers, query fields, and
+body presence.
+
+### Unmatched Requests
+
+Requests that match no coat, and requests hitting an exhausted `once` sequence,
+both return **404** with a JSON body (`{"error": ...}`).
+
 ### Validation Rules
 
 - `request.uri` is required
@@ -213,6 +242,19 @@ coats:
 - `body` and `body_file` are mutually exclusive (in both singular and plural forms)
 - `sequence` is only valid with `responses` (plural), must be `cycle` or `once`
 - Regex URIs (`~/` prefix) must compile as valid Go regexps
+- `body_match` must be `exact`, `glob`, `contains` or `regex`, and requires
+  `request.body` to be set; with `regex`, the body must compile as a Go regexp
+- `body_file` must be a relative path with no `..` components
+- `delay_ms` and `delay_jitter_ms` must be non-negative, and combined must not
+  exceed `coat.MaxDelayMs` (60000)
+
+`ValidateWithWarnings` also returns non-fatal **warnings** alongside errors:
+duplicate coat names, and regex URIs simple enough to be expressed as globs.
+`Validate` returns the errors only.
+
+`coatfile.schema.json` duplicates this schema for editor completion. Nothing in
+the build or test suite enforces that it stays in sync — when you add or change
+a coat field, update it by hand in the same commit.
 
 ### Key Dependencies
 
@@ -259,6 +301,9 @@ srv := trenchcoat.NewServer(
 srv.Start(t) // registers t.Cleanup to stop the server
 // srv.URL contains "http://127.0.0.1:<port>"
 ```
+
+`Request.Body` is a `*string` so an empty body can be distinguished from no body
+constraint — use `trenchcoat.StringPtr("...")` to set it.
 
 Available options:
 - `WithCoat(Coat)` — add a single coat


### PR DESCRIPTION
Docs-only. Audited `CLAUDE.md` against the actual code — every flag, dependency, toolchain version and Makefile target it documents was verified accurate, and the documented build/test commands were run and pass. What follows is the gap list that audit produced.

## Response body templating was entirely undocumented

`internal/server/server.go:231` runs every response body through a Go `text/template` when it contains `{{`, with request-aware fields (`.Method`, `.Path`, `.Body`, `.Query "key"`, `.Segment N`). This happens *after* `body_file` resolution, so fixture file contents are templated too. Neither `CLAUDE.md` nor the README mentioned it. It is also a trap worth stating plainly: a mock body that legitimately contains `{{` is silently treated as a template.

## The validation rules list was less than half complete

`internal/coat/validate.go` enforces four rules the docs didn't list, including a path-traversal guard on `body_file` (must be relative, no `..` components) and the delay bounds (`delay_ms` + `delay_jitter_ms` combined must not exceed `MaxDelayMs`). The distinction between `Validate` and `ValidateWithWarnings` — and the fact that non-fatal warnings exist at all — was also absent.

## `coatfile.schema.json` is hand-maintained and unenforced

158 lines at repo root, referenced by nothing else in the repo, with no test asserting it matches `internal/coat/types.go`. Adding a coat field silently desyncs it. That obligation is now written down where it will be read before the next schema change.

## Smaller gaps

- `internal/httputil/` was missing from the structure tree despite being used by both `matcher` and `server`.
- Unmatched requests and exhausted `once` sequences both return 404 with a JSON error body — now stated.
- `Request.Body` is a `*string`, so the programmatic API needs `trenchcoat.StringPtr(...)`. Verified this helper is genuinely re-exported at `trenchcoat.go:71` rather than assuming the `internal/coat` one was public.

## Deliberately not changed

The CLI flag lists duplicate the README. That is a currency risk in principle, but they are currently accurate and the README is not auto-loaded into an agent's context, so they earn their space.

## Follow-up worth considering

Response body templating is undocumented in the **README** too, so end users have no way to discover the feature. Out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z3nWoaTWaYM2R1wpsMEFL
