### PR TITLE
chore(claude): add gofmt and coat-schema-sync PostToolUse hooks

### DIFF
--- a/.claude/hooks/coat-schema-sync.py
+++ b/.claude/hooks/coat-schema-sync.py
@@ -17,10 +17,13 @@ real -- a hook that fires on every edit is a hook people learn to ignore.
 Test with: python3 .claude/hooks/test_hooks.py
 """
 
+from __future__ import annotations  # hooks may run under macOS system Python 3.9
+
 import json
 import os
 import subprocess
 import sys
+from pathlib import PurePath
 
 SCHEMA = "coatfile.schema.json"
 WATCHED = ("internal/coat/types.go", "internal/coat/validate.go")
@@ -84,7 +87,9 @@ def main() -> int:
         return 0
     repo_root = os.path.realpath(root.strip())
 
-    relative = os.path.relpath(path, repo_root)
+    # as_posix(): relpath yields OS-native separators, so on Windows this would
+    # be internal\coat\types.go and never match the forward-slash WATCHED entries.
+    relative = PurePath(os.path.relpath(path, repo_root)).as_posix()
     if relative not in WATCHED:
         return 0
 

--- a/.claude/hooks/coat-schema-sync.py
+++ b/.claude/hooks/coat-schema-sync.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: warn when the coat types drift from coatfile.schema.json.
+
+coatfile.schema.json hand-mirrors the coat schema defined by internal/coat's
+types and validation rules. Nothing in the build or test suite enforces that the
+two agree, and they have silently diverged before -- commit 46ff686 ("schema
+sync") fixed one such drift that only a human reviewer caught.
+
+So: whenever internal/coat/types.go or internal/coat/validate.go is edited and
+the schema is *not* also dirty in the working tree, tell Claude about it. The
+warning clears itself the moment the schema is touched, so it nags exactly until
+the job is done.
+
+Reads a PostToolUse payload on stdin. Emits nothing at all unless the drift is
+real -- a hook that fires on every edit is a hook people learn to ignore.
+
+Test with: python3 .claude/hooks/test_hooks.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+SCHEMA = "coatfile.schema.json"
+WATCHED = ("internal/coat/types.go", "internal/coat/validate.go")
+
+WARNING = (
+    f"{{edited}} was edited but {SCHEMA} is unchanged.\n"
+    f"{SCHEMA} hand-mirrors the coat schema and nothing enforces that they "
+    f"agree. If this edit added, removed or renamed a coat field -- or changed "
+    f"a validation rule that the schema encodes -- update {SCHEMA} in the same "
+    f"commit. If the edit does not touch the schema surface, ignore this."
+)
+
+
+def git(repo: str, *args: str) -> str | None:
+    """Run a read-only git command, returning stdout or None if it fails."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", repo, *args],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    except OSError:
+        return None
+    return result.stdout if result.returncode == 0 else None
+
+
+def dirty_paths(repo_root: str) -> set[str]:
+    """Repo-relative paths with uncommitted changes."""
+    porcelain = git(repo_root, "status", "--porcelain")
+    if porcelain is None:
+        return set()
+
+    paths = set()
+    for line in porcelain.splitlines():
+        if not line.strip():
+            continue
+        # Format is "XY <path>", and renames appear as "old -> new".
+        path = line[3:].strip()
+        if " -> " in path:
+            path = path.split(" -> ", 1)[1]
+        paths.add(path.strip('"'))
+    return paths
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    path = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not path:
+        return 0
+
+    # realpath both sides: on macOS the temp and repo paths routinely differ by
+    # the /var -> /private/var symlink, which would break the relpath compare.
+    path = os.path.realpath(path)
+    root = git(os.path.dirname(path) or ".", "rev-parse", "--show-toplevel")
+    if root is None:
+        return 0
+    repo_root = os.path.realpath(root.strip())
+
+    relative = os.path.relpath(path, repo_root)
+    if relative not in WATCHED:
+        return 0
+
+    if SCHEMA in dirty_paths(repo_root):
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "hookSpecificOutput": {
+                    "hookEventName": "PostToolUse",
+                    "additionalContext": WARNING.format(edited=relative),
+                }
+            }
+        ),
+        flush=True,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/gofmt-on-write.py
+++ b/.claude/hooks/gofmt-on-write.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""PostToolUse hook: format a Go file immediately after Claude edits it.
+
+CLAUDE.md requires gofmt and goimports to be clean before every commit, and the
+CI "Format" job fails the build on any file they would change. Running both on
+the single file that was just edited keeps that promise without anyone having to
+remember it.
+
+Reads a PostToolUse payload on stdin and formats tool_input.file_path in place.
+Non-Go files, files that no longer exist, and missing formatters are all no-ops:
+a formatter is not worth interrupting the session over, and CI still backstops.
+
+Test with: python3 .claude/hooks/test_hooks.py
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+
+FORMATTERS = ("gofmt", "goimports")
+
+
+def find_formatter(name: str) -> str | None:
+    """Locate a formatter, falling back to GOPATH/bin.
+
+    Hooks do not inherit an interactive shell's PATH, so goimports -- which is
+    installed by `go install` rather than a package manager -- is routinely
+    absent from PATH here even though it works fine in a terminal.
+    """
+    found = shutil.which(name)
+    if found:
+        return found
+    fallback = os.path.expanduser(os.path.join("~", "go", "bin", name))
+    return fallback if os.access(fallback, os.X_OK) else None
+
+
+def main() -> int:
+    try:
+        payload = json.loads(sys.stdin.read())
+    except (json.JSONDecodeError, ValueError):
+        return 0
+
+    path = (payload.get("tool_input") or {}).get("file_path") or ""
+    if not path.endswith(".go") or not os.path.isfile(path):
+        return 0
+
+    for name in FORMATTERS:
+        formatter = find_formatter(name)
+        if formatter is None:
+            continue
+        subprocess.run(
+            [formatter, "-w", path],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/gofmt-on-write.py
+++ b/.claude/hooks/gofmt-on-write.py
@@ -13,6 +13,8 @@ a formatter is not worth interrupting the session over, and CI still backstops.
 Test with: python3 .claude/hooks/test_hooks.py
 """
 
+from __future__ import annotations  # hooks may run under macOS system Python 3.9
+
 import json
 import os
 import shutil
@@ -20,6 +22,31 @@ import subprocess
 import sys
 
 FORMATTERS = ("gofmt", "goimports")
+
+
+def gopath_bin() -> str:
+    """Best effort GOPATH/bin, without assuming the default GOPATH.
+
+    CI images and devcontainers routinely relocate GOPATH, so ~/go/bin is a
+    guess of last resort rather than the answer. `go env` is consulted only
+    when the environment does not already say.
+    """
+    gopath = os.environ.get("GOPATH", "")
+    if not gopath:
+        try:
+            result = subprocess.run(
+                ["go", "env", "GOPATH"],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if result.returncode == 0:
+                gopath = result.stdout.strip()
+        except OSError:
+            gopath = ""
+    if not gopath:
+        gopath = os.path.expanduser(os.path.join("~", "go"))
+    return os.path.join(gopath, "bin")
 
 
 def find_formatter(name: str) -> str | None:
@@ -32,7 +59,7 @@ def find_formatter(name: str) -> str | None:
     found = shutil.which(name)
     if found:
         return found
-    fallback = os.path.expanduser(os.path.join("~", "go", "bin", name))
+    fallback = os.path.join(gopath_bin(), name)
     return fallback if os.access(fallback, os.X_OK) else None
 
 

--- a/.claude/hooks/test_hooks.py
+++ b/.claude/hooks/test_hooks.py
@@ -12,6 +12,8 @@ because the whole value of these hooks is that they agree with the tools CI
 runs.
 """
 
+from __future__ import annotations  # match the hooks: runnable on Python 3.9
+
 import json
 import os
 import shutil
@@ -25,7 +27,12 @@ GOFMT_HOOK = HOOKS_DIR / "gofmt-on-write.py"
 SCHEMA_HOOK = HOOKS_DIR / "coat-schema-sync.py"
 
 
-def run_hook(hook: Path, file_path: str, cwd: str | None = None):
+def run_hook(
+    hook: Path,
+    file_path: str,
+    cwd: str | None = None,
+    env: dict[str, str] | None = None,
+):
     """Invoke a hook with a PostToolUse payload, returning the CompletedProcess."""
     payload = json.dumps(
         {
@@ -40,6 +47,7 @@ def run_hook(hook: Path, file_path: str, cwd: str | None = None):
         capture_output=True,
         text=True,
         cwd=cwd,
+        env=env,
     )
 
 
@@ -112,6 +120,37 @@ class GofmtOnWriteTest(unittest.TestCase):
         result = run_hook(GOFMT_HOOK, os.path.join(self.tmp, "gone.go"))
 
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_finds_goimports_under_a_non_default_gopath(self):
+        """goimports lives in GOPATH/bin, which is not always ~/go/bin.
+
+        PATH is stripped to the system default and HOME is redirected at an
+        empty directory, so the only way to reach the formatter is by honouring
+        GOPATH. CI images and devcontainers routinely set it elsewhere.
+        """
+        gopath = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, gopath)
+        empty_home = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, empty_home)
+
+        bin_dir = Path(gopath) / "bin"
+        bin_dir.mkdir()
+        sentinel = Path(gopath) / "goimports-ran"
+        fake = bin_dir / "goimports"
+        fake.write_text(f'#!/bin/sh\necho "$@" > "{sentinel}"\n')
+        fake.chmod(0o755)
+
+        path = self.write("main.go", UNFORMATTED_GO)
+        result = run_hook(
+            GOFMT_HOOK,
+            path,
+            env={"PATH": "/usr/bin:/bin", "HOME": empty_home, "GOPATH": gopath},
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(
+            sentinel.exists(), "goimports in GOPATH/bin was never invoked"
+        )
 
     def test_is_silent_on_success(self):
         """A formatter that chatters on every edit becomes noise to ignore."""

--- a/.claude/hooks/test_hooks.py
+++ b/.claude/hooks/test_hooks.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Tests for the trenchcoat Claude Code hooks.
+
+Run with:
+
+    python3 .claude/hooks/test_hooks.py
+
+The hooks are exercised end to end: each test spawns the real hook script with a
+real PostToolUse payload on stdin and asserts on the files it touched and the
+JSON it emitted. Real gofmt, goimports and git are used -- nothing is mocked,
+because the whole value of these hooks is that they agree with the tools CI
+runs.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+HOOKS_DIR = Path(__file__).resolve().parent
+GOFMT_HOOK = HOOKS_DIR / "gofmt-on-write.py"
+SCHEMA_HOOK = HOOKS_DIR / "coat-schema-sync.py"
+
+
+def run_hook(hook: Path, file_path: str, cwd: str | None = None):
+    """Invoke a hook with a PostToolUse payload, returning the CompletedProcess."""
+    payload = json.dumps(
+        {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": file_path},
+        }
+    )
+    return subprocess.run(
+        [str(hook)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        cwd=cwd,
+    )
+
+
+def git(repo: str, *args: str) -> None:
+    """Run a git command in repo with a self-contained identity.
+
+    Signing is forced off so the tests never reach for Dan's signing key.
+    """
+    subprocess.run(
+        [
+            "git",
+            "-C",
+            repo,
+            "-c",
+            "user.email=test@example.com",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "commit.gpgsign=false",
+            *args,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+UNFORMATTED_GO = "package main\nfunc  main( ) {\nx:=1\n_ = x\n}\n"
+UNUSED_IMPORT_GO = 'package main\n\nimport "os"\n\nfunc main() {}\n'
+
+
+class GofmtOnWriteTest(unittest.TestCase):
+    """The formatter hook keeps edited Go files in the shape CI demands."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmp)
+
+    def write(self, name: str, content: str) -> str:
+        path = os.path.join(self.tmp, name)
+        Path(path).write_text(content)
+        return path
+
+    def test_formats_unformatted_go_file(self):
+        path = self.write("main.go", UNFORMATTED_GO)
+
+        result = run_hook(GOFMT_HOOK, path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("func main() {", Path(path).read_text())
+
+    def test_removes_unused_import(self):
+        """Proves goimports runs, not just gofmt -- gofmt leaves this alone."""
+        path = self.write("unused.go", UNUSED_IMPORT_GO)
+
+        result = run_hook(GOFMT_HOOK, path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn('"os"', Path(path).read_text())
+
+    def test_leaves_non_go_files_untouched(self):
+        original = "#  Heading\n\n\n   ragged    text\n"
+        path = self.write("notes.md", original)
+
+        result = run_hook(GOFMT_HOOK, path)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(Path(path).read_text(), original)
+
+    def test_missing_file_is_not_an_error(self):
+        result = run_hook(GOFMT_HOOK, os.path.join(self.tmp, "gone.go"))
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_is_silent_on_success(self):
+        """A formatter that chatters on every edit becomes noise to ignore."""
+        path = self.write("main.go", UNFORMATTED_GO)
+
+        result = run_hook(GOFMT_HOOK, path)
+
+        self.assertEqual(result.stdout, "")
+
+
+class CoatSchemaSyncTest(unittest.TestCase):
+    """The desync hook nags when the coat types drift from the JSON Schema."""
+
+    def setUp(self):
+        self.repo = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.repo)
+        git(self.repo, "init")
+        coat_dir = Path(self.repo) / "internal" / "coat"
+        coat_dir.mkdir(parents=True)
+        (coat_dir / "types.go").write_text("package coat\n\ntype Coat struct{}\n")
+        (coat_dir / "validate.go").write_text("package coat\n\nfunc Validate() {}\n")
+        (Path(self.repo) / "coatfile.schema.json").write_text('{"title": "coat"}\n')
+        (Path(self.repo) / "README.md").write_text("# trenchcoat\n")
+        git(self.repo, "add", "-A")
+        git(self.repo, "commit", "-m", "initial")
+
+    def path(self, *parts: str) -> str:
+        return os.path.join(self.repo, *parts)
+
+    def touch(self, *parts: str) -> str:
+        target = Path(self.path(*parts))
+        target.write_text(target.read_text() + "\n// changed\n")
+        return str(target)
+
+    def additional_context(self, result) -> str:
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(result.stdout.strip(), "expected JSON on stdout")
+        payload = json.loads(result.stdout)
+        hook_output = payload["hookSpecificOutput"]
+        self.assertEqual(hook_output["hookEventName"], "PostToolUse")
+        return hook_output["additionalContext"]
+
+    def test_warns_when_types_change_without_schema(self):
+        edited = self.touch("internal", "coat", "types.go")
+
+        result = run_hook(SCHEMA_HOOK, edited, cwd=self.repo)
+
+        self.assertIn("coatfile.schema.json", self.additional_context(result))
+
+    def test_warns_when_validate_changes_without_schema(self):
+        edited = self.touch("internal", "coat", "validate.go")
+
+        result = run_hook(SCHEMA_HOOK, edited, cwd=self.repo)
+
+        self.assertIn("coatfile.schema.json", self.additional_context(result))
+
+    def test_silent_when_schema_changed_too(self):
+        edited = self.touch("internal", "coat", "types.go")
+        self.touch("coatfile.schema.json")
+
+        result = run_hook(SCHEMA_HOOK, edited, cwd=self.repo)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_silent_for_unrelated_file(self):
+        edited = self.touch("README.md")
+
+        result = run_hook(SCHEMA_HOOK, edited, cwd=self.repo)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+
+    def test_silent_outside_a_git_repo(self):
+        loose = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, loose)
+        stray = Path(loose) / "types.go"
+        stray.write_text("package coat\n")
+
+        result = run_hook(SCHEMA_HOOK, str(stray), cwd=loose)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,19 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/gofmt-on-write.py"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/coat-schema-sync.py"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,12 @@ docs/
 trenchcoat.go             Public API package for Go test integration
 trenchcoat_test.go        Public API tests
 coatfile.schema.json      JSON Schema for coat files (hand-maintained — see Validation Rules)
+.claude/
+  settings.json           Checked-in Claude Code config (PostToolUse hooks)
+  hooks/
+    gofmt-on-write.py     Formats each Go file as it is edited
+    coat-schema-sync.py   Warns when coat types drift from coatfile.schema.json
+    test_hooks.py         Tests for both hooks
 .github/workflows/ci.yaml  CI pipeline (test, lint, vet, format, build)
 .goreleaser.yaml          GoReleaser config for cross-platform releases
 renovate.json             Renovate dependency auto-update config
@@ -96,6 +102,39 @@ goimports -w .                          # Fix imports
 golangci-lint run ./...                 # Lint
 govulncheck ./...                       # Vulnerability check
 ```
+
+### Claude Code Hooks
+
+`.claude/settings.json` is checked in and registers two `PostToolUse` hooks that
+fire after Claude edits a file. Both are deliberately silent unless they have
+something to say.
+
+| Hook | Fires on | Does |
+|------|----------|------|
+| `gofmt-on-write.py` | any `.go` file | Runs `gofmt -w` then `goimports -w` on that one file |
+| `coat-schema-sync.py` | `internal/coat/types.go`, `internal/coat/validate.go` | Warns if `coatfile.schema.json` is not also dirty in the working tree |
+
+The formatter only sees files **Claude** edits — your own editor changes are not
+covered, so the pre-commit checks below still stand. It is a safety net for the
+CI Format job, not a replacement for the manual pass.
+
+The schema hook exists because `coatfile.schema.json` hand-mirrors the coat
+schema and nothing enforces that they agree; the warning clears as soon as the
+schema is touched. See the Validation Rules section.
+
+Both scripts are plain stdlib Python with no dependencies, and must stay
+runnable under **Python 3.9** — macOS ships 3.9.6 as `/usr/bin/python3`, and the
+`#!/usr/bin/env python3` shebang resolves to whatever is first on `PATH`. That
+rules out PEP 604 (`str | None`) annotations unless
+`from __future__ import annotations` is present.
+
+```bash
+python3 .claude/hooks/test_hooks.py     # Test both hooks
+```
+
+The tests drive the real hook scripts against real `gofmt`, `goimports` and
+`git` in throwaway repos. Nothing is mocked — the point of the hooks is that
+they agree with the tools CI runs.
 
 ### Build with Version Info
 
@@ -254,7 +293,8 @@ duplicate coat names, and regex URIs simple enough to be expressed as globs.
 
 `coatfile.schema.json` duplicates this schema for editor completion. Nothing in
 the build or test suite enforces that it stays in sync — when you add or change
-a coat field, update it by hand in the same commit.
+a coat field, update it by hand in the same commit. The `coat-schema-sync.py`
+hook warns when you forget.
 
 ### Key Dependencies
 
@@ -359,6 +399,9 @@ go test -race ./...         # Run tests with race detector
 
 All Go source files **must** be formatted with `gofmt` and `goimports` before
 committing. Unformatted code must not be committed.
+
+The `gofmt-on-write.py` hook already formats files Claude edits, but it does not
+see edits made any other way — run the above regardless.
 
 ## Conventions
 


### PR DESCRIPTION
Adds the two Claude Code hooks from the automation audit. Both are `PostToolUse` hooks wired in a checked-in `.claude/settings.json`, so they apply for anyone working on trenchcoat rather than living in a gitignored local settings file.

## `gofmt-on-write.py`

Runs `gofmt -w` then `goimports -w` on each `.go` file as it is edited. `CLAUDE.md` requires both to be clean before every commit and CI has a dedicated **Format** job that hard-fails on either, so this converts a remembered manual step into an invariant.

`goimports` is installed via `go install` rather than a package manager, and hooks do not inherit an interactive shell's `PATH`, so the hook falls back to `GOPATH/bin` when `which` comes up empty. Missing formatters, non-Go files and deleted paths are all silent no-ops — a formatter is not worth interrupting a session over, and CI still backstops.

## `coat-schema-sync.py`

Warns when `internal/coat/types.go` or `validate.go` is edited while `coatfile.schema.json` stays clean in the working tree.

This is not hypothetical. `coatfile.schema.json` hand-mirrors the coat schema, nothing in the build or test suite enforces that the two agree, and they have already drifted once — `46ff686` is titled in part *"schema sync"* and fixed a desync that only a human reviewer caught. Both near-term ROADMAP features (item 8's `when:` conditions, item 9's `defaults:` block) add coat fields, which is precisely the shape that triggers it.

The warning clears the moment the schema is touched, so it nags exactly until the job is done and is otherwise completely silent. A hook that fires on every edit is one people learn to ignore.

## Verification

Built TDD — tests written first, watched fail with `FileNotFoundError` (10 tests, hooks absent), then implemented to green.

`test_hooks.py` runs both hooks as real subprocesses with real `PostToolUse` payloads against real `gofmt`, `goimports` and `git` in throwaway repos. Nothing is mocked, because the entire value of these hooks is that they agree with the tools CI actually runs. Coverage includes the negative cases that matter: non-Go files untouched, missing files not an error, silence when the schema was also updated, silence outside a git repo.

```
python3 .claude/hooks/test_hooks.py     # 10 tests, OK
```

Also verified beyond the fixtures: both hooks fire correctly against the real repo layout, the formatter leaves an already-formatted file byte-identical, and the project's full pre-commit gate is clean — `gofmt -l`, `goimports -l`, `go vet`, `golangci-lint run` (0 issues), `go test -race ./...` (all green).

Two implementation details were taken from the official `security-guidance` plugin rather than assumed: `PostToolUse` surfaces model-visible text via `hookSpecificOutput.additionalContext` on stdout with exit 0 (the legacy `stderr` + `exit(2)` shape was replaced for this event), and `CLAUDE_PROJECT_DIR` is a real hook variable.

## Review fixes

Three issues found in review, all fixed in `353fdec`:

- `find_formatter` promised a `GOPATH/bin` fallback while hard-coding `~/go/bin`, so `goimports` went silently unfound wherever `GOPATH` is relocated. Now reads `GOPATH` from the environment, falls back to `go env GOPATH`, then guesses `~/go`. Covered by a test that strips `PATH`, redirects `HOME`, and plants a fake `goimports` in a relocated `GOPATH/bin`.
- Writing that test exposed a worse bug nobody had flagged: both hooks used PEP 604 `str | None` annotations, which Python evaluates at runtime before 3.10. macOS ships 3.9.6 as `/usr/bin/python3`, so wherever the shebang resolved to the system interpreter, **both hooks died with a `TypeError` before doing any work**. Fixed with `from __future__ import annotations`; the suite now runs green under 3.9.6 and 3.14 alike.
- `os.path.relpath` returns OS-native separators, so the watched-path comparison could never match on Windows. Normalised via `PurePath(...).as_posix()`. Two caveats: this one is verified by inspection only (the bug is unreproducible on macOS, where `os.sep` is already `/`), and it does not make the hooks Windows-ready on its own — `settings.json` invokes them as bare paths relying on the shebang, which Windows does not honour.

## Documentation

Rebased onto main after #38 merged, and `CLAUDE.md` now documents both hooks: what they fire on, how to test them, and the two non-obvious constraints — the formatter only sees files Claude edits (so the manual pre-commit pass still stands), and the scripts must stay Python 3.9 compatible.

CI does run on this PR. `paths-ignore` skips a run only when every changed path matches one of its patterns, and `.claude/hooks/*.py` matches none of `docs/**`, `examples/**` or `**.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z3nWoaTWaYM2R1wpsMEFL
