### PR TITLE
fix: repo-wide review findings across proxy, matcher, server and validation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,6 +359,15 @@ hook warns when you forget.
   and `Accept-Language`. Recording them would tie a coat to the tool that
   captured it — a capture taken with curl would 404 for every other client.
   `Content-Type` and custom headers such as `X-Api-Key` are still captured.
+- Dropping `Accept` and `Accept-Language` has a known cost against a
+  content-negotiating upstream, where those headers select the representation
+  rather than describe the client. Capturing `GET /doc` with
+  `Accept: application/json` and again with `Accept: application/xml` produces
+  the same base name, so under the default `overwrite` the second capture
+  replaces the first and the surviving coat holds the XML body with no `Accept`
+  constraint — replaying the JSON request returns XML. Capture such an upstream
+  one representation at a time, into separate `--write-dir`s, and add the
+  `Accept` header to the coats by hand
 - Headers a peer scopes to one hop by naming them in its `Connection` header
   are withheld from the wire in both directions, and are not captured either —
   a coat recording them would demand, at replay, a header the upstream never

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,24 @@ warning and return the body unrendered.
 | Glob  | `**` multi-segment | `/api/**/posts/*`         |
 | Regex | `~/` prefix       | `~/api/v1/users/\d+`       |
 
+A URI is treated as a glob when it contains `*`, `?` or `[`. `[` is included
+because the underlying matcher is `doublestar`, so `/items[abc]` is a character
+class, not the literal path — quote or avoid `[` in exact URIs.
+
+### Header, Query and Body Globs
+
+Header values, query values and `body_match: glob` patterns use a *different*
+glob dialect from URIs, because these values are not paths:
+
+| Metacharacter | Matches                                        |
+|---------------|------------------------------------------------|
+| `*`           | any sequence of characters, `/` and `\n` included |
+| `?`           | any single character                           |
+
+Everything else, `[` included, matches literally. So `Content-Type: "*"` matches
+`application/json`, and `redirect: "*"` matches `/home/dash` — unlike URI globs,
+where `*` stops at a path segment boundary.
+
 ### Match Precedence (highest to lowest)
 
 1. Exact URI + method + headers + query

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -372,6 +372,11 @@ hook warns when you forget.
   are withheld from the wire in both directions, and are not captured either —
   a coat recording them would demand, at replay, a header the upstream never
   saw
+- A captured path containing a glob metacharacter (`*`, `?`, `[`) is recorded
+  with those characters **escaped**, so the coat means the path it was captured
+  from: `/api/items[abc]` is recorded as `/api/items\[abc\]`. Left unescaped it
+  would be read as a character class, and an unbalanced bracket would not
+  compile at all. Paths without a metacharacter are recorded verbatim
 - Captured `request.uri` is the **decoded** path, so `/files/dir%2Ffile` and
   `/files/dir/file` produce one coat even though they are different requests
   upstream; with `--dedupe skip` the second is discarded. Forwarding preserves

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,15 @@ hook warns when you forget.
 - File naming: `{METHOD}_{sanitised_path}_{status}.yaml`
 - Dedupe strategies: `overwrite` (stable filename), `skip`, `append`
 - Headers in `--strip-headers` are redacted from captures
+- Every request header a coat records becomes a **match constraint at replay**,
+  so client- and connection-specific headers are never captured: hop-by-hop
+  headers, `Content-Length`, `Host`, `User-Agent`, `Accept`, `Accept-Encoding`
+  and `Accept-Language`. Recording them would tie a coat to the tool that
+  captured it — a capture taken with curl would 404 for every other client.
+  `Content-Type` and custom headers such as `X-Api-Key` are still captured.
+- `Content-Length` is never recorded in a captured **response** either: the
+  captured body differs from the upstream body whenever it is pretty-printed or
+  decompressed, and `net/http` derives the correct length when serving
 - Gzip-compressed upstream responses are decompressed for readability in captured coats
 - Redirect responses are captured as-is (client does not follow redirects and returns the 3xx response as-is via `http.ErrUseLastResponse`)
 - To proxy to an upstream whose TLS certificate is issued for a different

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -254,13 +254,19 @@ warning and return the body unrendered.
 | Mode  | Syntax            | Example                    |
 |-------|-------------------|----------------------------|
 | Exact | Plain string      | `/api/v1/users`            |
-| Glob  | Contains `*`/?/`**` | `/api/v1/users/*`        |
+| Glob  | Contains `*`, `?`, `[` or `**` | `/api/v1/users/*` |
 | Glob  | `**` multi-segment | `/api/**/posts/*`         |
 | Regex | `~/` prefix       | `~/api/v1/users/\d+`       |
 
+Regex URIs are anchored as a group — `^(?:pattern)$` — so a top-level
+alternation is bounded as a whole: `~/users|/accounts` matches `/users` and
+`/accounts`, and neither `/users/extra` nor `/x/y/accounts`.
+
 A URI is treated as a glob when it contains `*`, `?` or `[`. `[` is included
 because the underlying matcher is `doublestar`, so `/items[abc]` is a character
-class, not the literal path — quote or avoid `[` in exact URIs.
+class rather than a literal path. To match a literal bracket, escape it with a
+backslash — `/items\[abc\]` — noting that the URI still counts as a glob and
+is matched as one; there is no way to make a bracketed URI an exact match.
 
 ### Header, Query and Body Globs
 
@@ -292,8 +298,20 @@ body presence.
 Requests that match no coat, and requests hitting an exhausted `once` sequence,
 both return **404** with a JSON body (`{"error": ...}`).
 
+A request that *matches* a coat defining neither `response` nor `responses`
+returns **500** naming the coat, and logs at `ERROR`: that is a fault in the
+coat rather than a request that found no match. Validation and `WithCoatFile`
+both reject such a coat, so this is only reachable via `WithCoat`/`WithCoats`.
+
 ### Validation Rules
 
+- Coat files are parsed **strictly**: an unknown YAML or JSON key is a parse
+  error naming the field, not a silently ignored one. Top-level keys beginning
+  `x-` are the one exception, so a file can hold a YAML anchor for coats to
+  merge in
+- A JSON coat file must contain exactly one document; anything after it is an
+  error
+- A URI containing `*`, `?` or `[` must be a valid `doublestar` pattern
 - `request.uri` is required
 - Must have exactly one of `response` (singular) or `responses` (plural)
 - `body` and `body_file` are mutually exclusive (in both singular and plural forms)
@@ -337,6 +355,14 @@ hook warns when you forget.
   and `Accept-Language`. Recording them would tie a coat to the tool that
   captured it — a capture taken with curl would 404 for every other client.
   `Content-Type` and custom headers such as `X-Api-Key` are still captured.
+- Headers a peer scopes to one hop by naming them in its `Connection` header
+  are withheld from the wire in both directions, and are not captured either —
+  a coat recording them would demand, at replay, a header the upstream never
+  saw
+- Captured `request.uri` is the **decoded** path, so `/files/dir%2Ffile` and
+  `/files/dir/file` produce one coat even though they are different requests
+  upstream; with `--dedupe skip` the second is discarded. Forwarding preserves
+  the encoding — it is only the capture that collapses
 - `Content-Length` is never recorded in a captured **response** either: the
   captured body differs from the upstream body whenever it is pretty-printed or
   decompressed, and `net/http` derives the correct length when serving

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,11 +306,29 @@ both reject such a coat, so this is only reachable via `WithCoat`/`WithCoats`.
 ### Validation Rules
 
 - Coat files are parsed **strictly**: an unknown YAML or JSON key is a parse
-  error naming the field, not a silently ignored one. Top-level **YAML** keys
-  beginning `x-` are the one exception, so a file can hold an anchor for coats
-  to merge in. JSON has no anchors, so a JSON `x-` key is an unknown field like
-  any other. `coatfile.schema.json` cannot tell the two formats apart, so it
-  describes the JSON rule and flags an `x-` key in either
+  error naming the field, not a silently ignored one. No prefix is exempt, in
+  either format: `coats` is the only top-level key a coat file may hold
+- To share a response fragment between coats without repeating it, anchor on
+  the response of the first coat that uses it and merge from the coats after:
+
+  ```yaml
+  coats:
+    - name: first
+      request: {uri: /a}
+      response: &defaults        # anchor on a real field, not a holder key
+        code: 200
+        headers: {Content-Type: application/json}
+    - name: second
+      request: {uri: /b}
+      response:
+        <<: *defaults            # code 200, Content-Type merged in
+    - name: third
+      request: {uri: /c}
+      response:
+        <<: *defaults
+        code: 201                # merged values can be overridden
+  ```
+
 - A coat file must contain exactly one document, in either format; anything
   after it is an error. A YAML file may still carry the markers of a single
   document — a leading `---`, a trailing `---` or `...` — but a second `---`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,8 +309,10 @@ both reject such a coat, so this is only reachable via `WithCoat`/`WithCoats`.
   error naming the field, not a silently ignored one. Top-level keys beginning
   `x-` are the one exception, so a file can hold a YAML anchor for coats to
   merge in
-- A JSON coat file must contain exactly one document; anything after it is an
-  error
+- A coat file must contain exactly one document, in either format; anything
+  after it is an error. A YAML file may still carry the markers of a single
+  document — a leading `---`, a trailing `---` or `...` — but a second `---`
+  document is rejected rather than silently ignored
 - A URI containing `*`, `?` or `[` must be a valid `doublestar` pattern
 - `request.uri` is required
 - Must have exactly one of `response` (singular) or `responses` (plural)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -306,9 +306,11 @@ both reject such a coat, so this is only reachable via `WithCoat`/`WithCoats`.
 ### Validation Rules
 
 - Coat files are parsed **strictly**: an unknown YAML or JSON key is a parse
-  error naming the field, not a silently ignored one. Top-level keys beginning
-  `x-` are the one exception, so a file can hold a YAML anchor for coats to
-  merge in
+  error naming the field, not a silently ignored one. Top-level **YAML** keys
+  beginning `x-` are the one exception, so a file can hold an anchor for coats
+  to merge in. JSON has no anchors, so a JSON `x-` key is an unknown field like
+  any other. `coatfile.schema.json` cannot tell the two formats apart, so it
+  describes the JSON rule and flags an `x-` key in either
 - A coat file must contain exactly one document, in either format; anything
   after it is an error. A YAML file may still carry the markers of a single
   document — a leading `---`, a trailing `---` or `...` — but a second `---`

--- a/cmd/trenchcoat/commands_test.go
+++ b/cmd/trenchcoat/commands_test.go
@@ -1419,3 +1419,138 @@ func signalAndWait(t *testing.T, cmd *exec.Cmd, stderr *bytes.Buffer, timeout ti
 		t.Fatal("timeout waiting for process to exit")
 	}
 }
+
+func TestBinary_ProxyThenServe_LocalUpstream(t *testing.T) {
+	// The same end-to-end round trip as TestBinary_ProxyThenServe -- real
+	// binary, real HTTP, real coat file on disk -- but against a local upstream
+	// so it cannot skip.
+	//
+	// Its sibling proxies to a third-party API and calls t.Skipf when that host
+	// is unreachable or returns a non-200. A silent skip means the most
+	// valuable path in the suite can vanish from CI without turning anything
+	// red, and it depends on someone else's uptime and rate limits. That test
+	// stays, because exercising a real API end to end is worth having; this one
+	// guarantees the capability is verified on every run regardless.
+	if testing.Short() {
+		t.Skip("skipping binary test in short mode")
+	}
+
+	const payload = `{"userId":1,"id":1,"title":"local","body":"upstream"}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/posts/1" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer upstream.Close()
+
+	httpClient := &http.Client{Timeout: 10 * time.Second}
+
+	binary := filepath.Join(t.TempDir(), "trenchcoat")
+	build := exec.Command("go", "build", "-o", binary, "./")
+	build.Dir = "."
+	if out, err := build.CombinedOutput(); err != nil {
+		t.Fatalf("failed to build binary: %v\n%s", err, out)
+	}
+
+	// Capture through the proxy.
+	writeDir := t.TempDir()
+	proxyPort := freePort(t)
+	proxyURL := fmt.Sprintf("http://127.0.0.1:%d", proxyPort)
+
+	proxyCmd := exec.Command(binary, "proxy",
+		upstream.URL,
+		"--port", fmt.Sprintf("%d", proxyPort),
+		"--write-dir", writeDir,
+		"--dedupe", "overwrite",
+	)
+	var proxyStderr bytes.Buffer
+	proxyCmd.Stderr = &proxyStderr
+	if err := proxyCmd.Start(); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = proxyCmd.Process.Signal(os.Kill)
+		_ = proxyCmd.Wait()
+	})
+	waitForHTTP(t, proxyURL+"/posts/1")
+
+	resp, err := httpClient.Get(proxyURL + "/posts/1")
+	if err != nil {
+		t.Fatalf("proxy request failed: %v", err)
+	}
+	capturedBody, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	if err != nil {
+		t.Fatalf("failed to read proxy response: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("expected 200 through the proxy, got %d", resp.StatusCode)
+	}
+	if string(capturedBody) != payload {
+		t.Fatalf("proxy did not relay the upstream body verbatim.\nwant: %s\ngot:  %s", payload, capturedBody)
+	}
+
+	// Stopping the proxy flushes pending captures.
+	signalAndWait(t, proxyCmd, &proxyStderr, 10*time.Second)
+
+	// The captured coat must satisfy the tool's own validator.
+	validateCmd := exec.Command(binary, "validate", writeDir)
+	if out, err := validateCmd.CombinedOutput(); err != nil {
+		t.Fatalf("validate rejected the captured coat: %v\n%s", err, out)
+	}
+
+	coatFile := filepath.Join(writeDir, "GET_posts_1_200.yaml")
+	parsed, err := coat.ParseFile(coatFile)
+	if err != nil {
+		t.Fatalf("failed to parse the captured coat: %v", err)
+	}
+	if len(parsed.Coats) != 1 {
+		t.Fatalf("expected 1 coat, got %d", len(parsed.Coats))
+	}
+	if got := parsed.Coats[0].Request.URI; got != "/posts/1" {
+		t.Fatalf("captured URI is %q, want /posts/1", got)
+	}
+
+	// Replay it, from a different client than the one that captured it.
+	servePort := freePort(t)
+	serveURL := fmt.Sprintf("http://127.0.0.1:%d", servePort)
+	serveCmd := exec.Command(binary, "serve", "--coats", writeDir, "--port", fmt.Sprintf("%d", servePort))
+	var serveStderr bytes.Buffer
+	serveCmd.Stderr = &serveStderr
+	if err := serveCmd.Start(); err != nil {
+		t.Fatalf("failed to start serve: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = serveCmd.Process.Signal(os.Kill)
+		_ = serveCmd.Wait()
+	})
+	waitForHTTP(t, serveURL+"/posts/1")
+
+	replayReq, err := http.NewRequest("GET", serveURL+"/posts/1", nil)
+	if err != nil {
+		t.Fatalf("failed to build replay request: %v", err)
+	}
+	replayReq.Header.Set("User-Agent", "some-other-tool/2.0")
+	serveResp, err := httpClient.Do(replayReq)
+	if err != nil {
+		t.Fatalf("serve request failed: %v", err)
+	}
+	serveBody, err := io.ReadAll(serveResp.Body)
+	_ = serveResp.Body.Close()
+	if err != nil {
+		t.Fatalf("failed to read serve response: %v", err)
+	}
+	if serveResp.StatusCode != 200 {
+		t.Fatalf("replaying the captured coat from a different client got %d: %s", serveResp.StatusCode, serveBody)
+	}
+
+	want := strings.TrimRight(string(capturedBody), "\n")
+	got := strings.TrimRight(string(serveBody), "\n")
+	if got != want {
+		t.Fatalf("replayed body does not match the capture.\nwant: %s\ngot:  %s", want, got)
+	}
+}

--- a/cmd/trenchcoat/commands_test.go
+++ b/cmd/trenchcoat/commands_test.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -1252,7 +1253,118 @@ coats:
 	}
 }
 
+func TestWatchCoats_ReloadFailureIsLoggedAsAnError(t *testing.T) {
+	// A reload that loses coats is worse than a startup that never loaded them:
+	// the server is already taking traffic, and a route it answered a moment ago
+	// starts 404ing with nothing in the response pointing at the cause. Strict
+	// parsing makes a file that was tolerated for months start failing
+	// mid-session, so the reload path has to be as loud as the startup path --
+	// an ERROR per failure and a summary carrying the count, not a Warn under a
+	// reassuring reload line.
+	dir := t.TempDir()
+	coatFile := filepath.Join(dir, "coat.yaml")
+	writeTestFile(t, coatFile, `
+coats:
+  - name: "served"
+    request:
+      uri: "/served"
+    response:
+      code: 200
+      body: "here"
+`)
+
+	var out lockedBuffer
+	logger := slog.New(slog.NewTextHandler(&out, nil))
+	loaded, errs := coat.LoadPaths([]string{dir})
+	if len(errs) > 0 {
+		t.Fatalf("LoadPaths errors: %v", errs)
+	}
+	srv := server.New(loaded, server.Config{Logger: logger})
+	if _, err := srv.Start("127.0.0.1:0"); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(5 * time.Second) })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		watchCoats(ctx, logger, srv, []string{dir})
+		close(done)
+	}()
+	time.Sleep(100 * time.Millisecond)
+
+	// Rewrite the file with a misspelt key. Strict parsing rejects the whole
+	// file, so /served stops being served on the next reload.
+	writeTestFile(t, coatFile, `
+coats:
+  - name: "served"
+    request:
+      mehtod: GET
+      uri: "/served"
+    response:
+      code: 200
+      body: "here"
+`)
+
+	deadline := time.After(3 * time.Second)
+	for {
+		logs := out.String()
+		if logLineHasAll(logs, "level=ERROR", "coat reload error") && logLineHasAll(logs, "level=ERROR", "errors=1") {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("a failed reload must log the failure and a summary at ERROR; log was:\n%s", logs)
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for watchCoats to return")
+	}
+}
+
 // --- helpers ---
+
+// logLineHasAll reports whether any single line of logs contains every
+// substring, so a level assertion cannot be satisfied by a different line.
+func logLineHasAll(logs string, substrings ...string) bool {
+	for _, line := range strings.Split(logs, "\n") {
+		matched := true
+		for _, s := range substrings {
+			if !strings.Contains(line, s) {
+				matched = false
+				break
+			}
+		}
+		if matched {
+			return true
+		}
+	}
+	return false
+}
+
+// lockedBuffer is an io.Writer a test can read while a logger on another
+// goroutine is still writing to it.
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
 
 func writeTestFile(t *testing.T, path, content string) {
 	t.Helper()

--- a/cmd/trenchcoat/serve.go
+++ b/cmd/trenchcoat/serve.go
@@ -186,10 +186,19 @@ func watchCoats(ctx context.Context, logger *slog.Logger, srv *server.Server, co
 			for _, w := range reloadResult.Warnings {
 				logger.Warn("coat validation warning", "warning", w)
 			}
+			// Load failures are logged at Error for the same reason as on
+			// startup, and with more cause: the server is already taking
+			// traffic, so a file that stops parsing takes routes that were
+			// being answered a moment ago out of service. The summary carries
+			// the error count too, so the reload count on its own cannot read
+			// as a clean reload.
 			for _, e := range reloadResult.Errors {
-				logger.Warn("reload error", "error", e)
+				logger.Error("coat reload error", "error", e)
 			}
 			srv.Reload(reloadResult.Coats)
+			if len(reloadResult.Errors) > 0 {
+				logger.Error("coats reloaded with errors", "count", len(reloadResult.Coats), "errors", len(reloadResult.Errors))
+			}
 		case event, ok := <-watcher.Events:
 			if !ok {
 				return

--- a/cmd/trenchcoat/serve.go
+++ b/cmd/trenchcoat/serve.go
@@ -85,10 +85,18 @@ func runServe(cmd *cobra.Command, args []string) error {
 	for _, w := range loadResult.Warnings {
 		logger.Warn("coat validation warning", "warning", w)
 	}
+	// Load failures are logged at Error, not Warn. A file that fails to parse
+	// contributes none of its coats, so every route it defined now 404s with
+	// nothing in the response pointing at the cause -- a warning buried above a
+	// cheerful "coats loaded" line is not enough to find that from the outside.
 	for _, e := range loadResult.Errors {
-		logger.Warn("coat loading error", "error", e)
+		logger.Error("coat loading error", "error", e)
 	}
-	logger.Info("coats loaded", "count", len(loaded))
+	if len(loadResult.Errors) > 0 {
+		logger.Info("coats loaded", "count", len(loaded), "errors", len(loadResult.Errors))
+	} else {
+		logger.Info("coats loaded", "count", len(loaded))
+	}
 
 	srv := server.New(loaded, server.Config{
 		Verbose: verbose,

--- a/coatfile.schema.json
+++ b/coatfile.schema.json
@@ -17,11 +17,6 @@
       }
     }
   },
-  "patternProperties": {
-    "^x-": {
-      "description": "Extension key ignored by Trenchcoat. Exists so a coat file can hold a YAML anchor for coats to merge in; any other unknown top-level key is a parse error."
-    }
-  },
   "$defs": {
     "coat": {
       "description": "An individual request/response mock definition.",

--- a/coatfile.schema.json
+++ b/coatfile.schema.json
@@ -4,7 +4,9 @@
   "title": "Trenchcoat Coat File",
   "description": "Schema for Trenchcoat coat files defining HTTP request/response mocks.",
   "type": "object",
-  "required": ["coats"],
+  "required": [
+    "coats"
+  ],
   "additionalProperties": false,
   "properties": {
     "coats": {
@@ -15,11 +17,18 @@
       }
     }
   },
+  "patternProperties": {
+    "^x-": {
+      "description": "Extension key ignored by Trenchcoat. Exists so a coat file can hold a YAML anchor for coats to merge in; any other unknown top-level key is a parse error."
+    }
+  },
   "$defs": {
     "coat": {
       "description": "An individual request/response mock definition.",
       "type": "object",
-      "required": ["request"],
+      "required": [
+        "request"
+      ],
       "additionalProperties": false,
       "properties": {
         "name": {
@@ -43,19 +52,26 @@
         "sequence": {
           "description": "Sequence mode for plural responses. Only valid with 'responses'.",
           "type": "string",
-          "enum": ["cycle", "once"]
+          "enum": [
+            "cycle",
+            "once"
+          ]
         }
       },
       "oneOf": [
         {
-          "required": ["response"],
+          "required": [
+            "response"
+          ],
           "properties": {
             "responses": false,
             "sequence": false
           }
         },
         {
-          "required": ["responses"],
+          "required": [
+            "responses"
+          ],
           "properties": {
             "response": false
           }
@@ -65,7 +81,9 @@
     "request": {
       "description": "Matching criteria for an incoming HTTP request.",
       "type": "object",
-      "required": ["uri"],
+      "required": [
+        "uri"
+      ],
       "additionalProperties": false,
       "properties": {
         "method": {
@@ -105,7 +123,12 @@
         "body_match": {
           "description": "Body matching mode: exact (default), glob, contains, or regex.",
           "type": "string",
-          "enum": ["exact", "glob", "contains", "regex"],
+          "enum": [
+            "exact",
+            "glob",
+            "contains",
+            "regex"
+          ],
           "default": "exact"
         }
       }
@@ -151,7 +174,10 @@
         }
       },
       "not": {
-        "required": ["body", "body_file"]
+        "required": [
+          "body",
+          "body_file"
+        ]
       }
     }
   }

--- a/internal/coat/parse.go
+++ b/internal/coat/parse.go
@@ -111,6 +111,11 @@ func parseFileWith(path, format string, unmarshal func([]byte, any) error) (*Fil
 	// That exists for one idiom: a key whose only job is to hold a YAML anchor
 	// that coats below merge in. Everything else is a typo, and letting a typo
 	// through is what strict decoding is for.
+	//
+	// Only YAML ever reaches this loop. Extensions is json:"-", so a JSON x- key
+	// is an unknown field to the JSON decoder and is refused there -- which is
+	// the intended scope, since JSON has no anchors and so no use for the idiom.
+	// The format is still named in the message because parseFileWith is shared.
 	for key := range f.Extensions {
 		if !strings.HasPrefix(key, "x-") {
 			return nil, fmt.Errorf("parsing %s coat file %s: unknown top-level field %q (only \"x-\" prefixed extension keys are allowed)", format, path, key)

--- a/internal/coat/parse.go
+++ b/internal/coat/parse.go
@@ -37,6 +37,13 @@ func ParseFile(path string) (*File, error) {
 // a misspelt 'mehtod' leaves the coat defaulting to GET, so the POSTs it was
 // written for 404 while unintended GETs match, and `trenchcoat validate` calls
 // the file clean.
+//
+// It also rejects anything after the first document. yaml.Decoder.Decode reads
+// one document and stops, so without this check every coat after a '---'
+// separator silently does not exist, and syntactically broken content after a
+// document is accepted without a word. A null document is tolerated so the
+// markers a single-document file may carry -- a trailing '---' or '...' -- keep
+// working.
 func unmarshalStrictYAML(data []byte, v any) error {
 	dec := yaml.NewDecoder(bytes.NewReader(data))
 	dec.KnownFields(true)
@@ -48,7 +55,20 @@ func unmarshalStrictYAML(data []byte, v any) error {
 		}
 		return err
 	}
-	return nil
+
+	for {
+		var extra any
+		err := dec.Decode(&extra)
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if extra != nil {
+			return fmt.Errorf("unexpected content after the YAML document")
+		}
+	}
 }
 
 // unmarshalStrictJSON decodes JSON, rejecting unknown keys for the same reason.

--- a/internal/coat/parse.go
+++ b/internal/coat/parse.go
@@ -107,21 +107,6 @@ func parseFileWith(path, format string, unmarshal func([]byte, any) error) (*Fil
 		return nil, fmt.Errorf("parsing %s coat file %s: %w", format, path, err)
 	}
 
-	// Top-level keys outside the schema are accepted only as "x-" extensions.
-	// That exists for one idiom: a key whose only job is to hold a YAML anchor
-	// that coats below merge in. Everything else is a typo, and letting a typo
-	// through is what strict decoding is for.
-	//
-	// Only YAML ever reaches this loop. Extensions is json:"-", so a JSON x- key
-	// is an unknown field to the JSON decoder and is refused there -- which is
-	// the intended scope, since JSON has no anchors and so no use for the idiom.
-	// The format is still named in the message because parseFileWith is shared.
-	for key := range f.Extensions {
-		if !strings.HasPrefix(key, "x-") {
-			return nil, fmt.Errorf("parsing %s coat file %s: unknown top-level field %q (only \"x-\" prefixed extension keys are allowed)", format, path, key)
-		}
-	}
-
 	return &f, nil
 }
 

--- a/internal/coat/parse.go
+++ b/internal/coat/parse.go
@@ -1,8 +1,11 @@
 package coat
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,12 +23,45 @@ func ParseFile(path string) (*File, error) {
 	ext := strings.ToLower(filepath.Ext(path))
 	switch ext {
 	case ".yaml", ".yml":
-		return parseFileWith(path, "YAML", yaml.Unmarshal)
+		return parseFileWith(path, "YAML", unmarshalStrictYAML)
 	case ".json":
-		return parseFileWith(path, "JSON", json.Unmarshal)
+		return parseFileWith(path, "JSON", unmarshalStrictJSON)
 	default:
 		return nil, fmt.Errorf("unrecognised coat file extension %q: expected .yaml, .yml, or .json", ext)
 	}
+}
+
+// unmarshalStrictYAML decodes YAML, rejecting keys that do not correspond to a
+// field. coatfile.schema.json sets additionalProperties: false throughout, and
+// silently discarding unknown keys contradicts that in the way that costs most:
+// a misspelt 'mehtod' leaves the coat defaulting to GET, so the POSTs it was
+// written for 404 while unintended GETs match, and `trenchcoat validate` calls
+// the file clean.
+func unmarshalStrictYAML(data []byte, v any) error {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+	if err := dec.Decode(v); err != nil {
+		// An empty document is not an error: it yields a File with no coats,
+		// which the existing behaviour allowed and validation reports on.
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// unmarshalStrictJSON decodes JSON, rejecting unknown keys for the same reason.
+func unmarshalStrictJSON(data []byte, v any) error {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.DisallowUnknownFields()
+	if err := dec.Decode(v); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func parseFileWith(path, format string, unmarshal func([]byte, any) error) (*File, error) {

--- a/internal/coat/parse.go
+++ b/internal/coat/parse.go
@@ -52,6 +52,11 @@ func unmarshalStrictYAML(data []byte, v any) error {
 }
 
 // unmarshalStrictJSON decodes JSON, rejecting unknown keys for the same reason.
+//
+// It also rejects anything after the document. json.Unmarshal required the
+// whole input to be a single value; json.Decoder.Decode reads one value and
+// stops, so without this check a second appended object -- or any trailing
+// garbage -- loads silently and the coats after it simply do not exist.
 func unmarshalStrictJSON(data []byte, v any) error {
 	dec := json.NewDecoder(bytes.NewReader(data))
 	dec.DisallowUnknownFields()
@@ -60,6 +65,10 @@ func unmarshalStrictJSON(data []byte, v any) error {
 			return nil
 		}
 		return err
+	}
+
+	if dec.More() {
+		return fmt.Errorf("unexpected content after the JSON document")
 	}
 	return nil
 }
@@ -77,6 +86,17 @@ func parseFileWith(path, format string, unmarshal func([]byte, any) error) (*Fil
 	if err := unmarshal(data, &f); err != nil {
 		return nil, fmt.Errorf("parsing %s coat file %s: %w", format, path, err)
 	}
+
+	// Top-level keys outside the schema are accepted only as "x-" extensions.
+	// That exists for one idiom: a key whose only job is to hold a YAML anchor
+	// that coats below merge in. Everything else is a typo, and letting a typo
+	// through is what strict decoding is for.
+	for key := range f.Extensions {
+		if !strings.HasPrefix(key, "x-") {
+			return nil, fmt.Errorf("parsing %s coat file %s: unknown top-level field %q (only \"x-\" prefixed extension keys are allowed)", format, path, key)
+		}
+	}
+
 	return &f, nil
 }
 

--- a/internal/coat/parse_test.go
+++ b/internal/coat/parse_test.go
@@ -571,3 +571,85 @@ func TestParseFile_KnownFieldsStillParse(t *testing.T) {
 		t.Fatalf("expected the file to validate, got: %v", errs)
 	}
 }
+
+func TestParseFile_RejectsTrailingContent(t *testing.T) {
+	// json.Decoder reads one value and stops, unlike json.Unmarshal which
+	// required the whole input to be a single document. Without an explicit
+	// check, a second appended object or trailing garbage loads silently and
+	// half the file's coats simply do not exist.
+	dir := t.TempDir()
+
+	for name, body := range map[string]string{
+		"second-document.json":  `{"coats":[{"name":"a","request":{"uri":"/a"},"response":{"code":200}}]}{"coats":[]}`,
+		"trailing-garbage.json": `{"coats":[{"name":"a","request":{"uri":"/a"},"response":{"code":200}}]} garbage`,
+	} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := coat.ParseFile(path); err == nil {
+			t.Errorf("%s: expected an error for content after the JSON document", name)
+		}
+	}
+}
+
+func TestParseFile_EmptyFileIsNotAnError(t *testing.T) {
+	// An empty or comment-only file yields a File with no coats, which is what
+	// yaml.Unmarshal and json.Unmarshal did before strict decoding. Nothing
+	// covered this, so deleting the io.EOF guard left the whole suite green.
+	dir := t.TempDir()
+
+	cases := map[string]string{
+		"empty.yaml":   "",
+		"comment.yaml": "# nothing here yet\n",
+		"empty.json":   "",
+	}
+	for name, body := range cases {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+		f, err := coat.ParseFile(path)
+		if err != nil {
+			t.Errorf("%s: expected no error, got %v", name, err)
+			continue
+		}
+		if len(f.Coats) != 0 {
+			t.Errorf("%s: expected zero coats, got %d", name, len(f.Coats))
+		}
+	}
+}
+
+func TestParseFile_AllowsTopLevelExtensionKeys(t *testing.T) {
+	// Strict decoding must not break the anchor-holder idiom: a top-level x-
+	// key exists purely to carry a YAML anchor that coats then merge in. Merge
+	// keys always worked; it was the key holding the anchor that stopped
+	// parsing. Any other unknown key is still an error.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "anchors.yaml")
+	body := `x-defaults: &defaults
+  code: 200
+  headers:
+    Content-Type: application/json
+coats:
+  - name: uses-anchor
+    request:
+      uri: /api/users
+    response:
+      <<: *defaults
+`
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := coat.ParseFile(path)
+	if err != nil {
+		t.Fatalf("a top-level x- key holding an anchor must parse, got: %v", err)
+	}
+	if len(f.Coats) != 1 {
+		t.Fatalf("expected 1 coat, got %d", len(f.Coats))
+	}
+	if got := f.Coats[0].Response.Code; got != 200 {
+		t.Fatalf("merged anchor should set code 200, got %d", got)
+	}
+}

--- a/internal/coat/parse_test.go
+++ b/internal/coat/parse_test.go
@@ -2,6 +2,7 @@ package coat_test
 
 import (
 	"os"
+	"strings"
 	"path/filepath"
 	"testing"
 
@@ -490,5 +491,83 @@ func assertEqual[T comparable](t *testing.T, field string, expected, actual T) {
 	t.Helper()
 	if expected != actual {
 		t.Errorf("%s: expected %v, got %v", field, expected, actual)
+	}
+}
+
+func TestParseFile_UnknownFieldIsAnError(t *testing.T) {
+	// coatfile.schema.json sets additionalProperties: false throughout, but the
+	// parsers discarded unknown keys, so a typo validated clean and quietly
+	// changed behaviour: 'mehtod: POST' left the coat defaulting to GET, so the
+	// intended POSTs 404'd and unintended GETs matched.
+	dir := t.TempDir()
+
+	yamlPath := filepath.Join(dir, "typo.yaml")
+	yamlBody := "coats:\n  - name: typo\n    request:\n      mehtod: POST\n      uri: /api/users\n    response:\n      code: 200\n"
+	if err := os.WriteFile(yamlPath, []byte(yamlBody), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := coat.ParseFile(yamlPath); err == nil {
+		t.Fatal("expected a parse error naming the unknown YAML field 'mehtod'")
+	} else if !strings.Contains(err.Error(), "mehtod") {
+		t.Fatalf("parse error should name the offending field, got: %v", err)
+	}
+
+	jsonPath := filepath.Join(dir, "typo.json")
+	jsonBody := `{"coats":[{"name":"typo","request":{"heders":{"A":"b"},"uri":"/x"},"response":{"code":200}}]}`
+	if err := os.WriteFile(jsonPath, []byte(jsonBody), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := coat.ParseFile(jsonPath); err == nil {
+		t.Fatal("expected a parse error naming the unknown JSON field 'heders'")
+	} else if !strings.Contains(err.Error(), "heders") {
+		t.Fatalf("parse error should name the offending field, got: %v", err)
+	}
+}
+
+func TestParseFile_KnownFieldsStillParse(t *testing.T) {
+	// The strict decoder must not reject anything the schema allows.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "full.yaml")
+	body := `coats:
+  - name: full
+    request:
+      method: POST
+      uri: /api/users
+      headers:
+        Content-Type: application/json
+      query:
+        page: "1"
+      body: '{"n":1}'
+      body_match: exact
+    response:
+      code: 201
+      headers:
+        Content-Type: application/json
+      body: '{"ok":true}'
+      delay_ms: 1
+      delay_jitter_ms: 1
+  - name: sequence
+    request:
+      uri: /seq
+    responses:
+      - code: 503
+      - code: 200
+    sequence: once
+`
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := coat.ParseFile(path)
+	if err != nil {
+		t.Fatalf("a coat file using every documented field must parse, got: %v", err)
+	}
+	if len(f.Coats) != 2 {
+		t.Fatalf("expected 2 coats, got %d", len(f.Coats))
+	}
+	if errs := coat.Validate(f); len(errs) > 0 {
+		t.Fatalf("expected the file to validate, got: %v", errs)
 	}
 }

--- a/internal/coat/parse_test.go
+++ b/internal/coat/parse_test.go
@@ -652,42 +652,56 @@ func TestParseFile_EmptyFileIsNotAnError(t *testing.T) {
 	}
 }
 
-func TestParseFile_RejectsExtensionKeysInJSON(t *testing.T) {
-	// The x- allowance is scoped to YAML, where it exists to carry an anchor.
-	// JSON has no anchors and so no use for it, and Extensions is json:"-" so a
-	// JSON x- key is an unknown field like any other. Pinned because the
-	// shipped schema and the documentation have both claimed otherwise.
+func TestParseFile_RejectsTopLevelExtensionKeys(t *testing.T) {
+	// No top-level key outside the schema is accepted, in either format: an
+	// "x-" prefix is no exemption. A holder key for a YAML anchor is the one
+	// tempting reason to want one, and the inline anchor covered by
+	// TestParseFile_SharesResponseDefaultsViaInlineAnchor serves that instead.
 	dir := t.TempDir()
-	path := filepath.Join(dir, "ext.json")
-	body := `{"x-defaults":{"code":200},"coats":[{"name":"a","request":{"uri":"/a"},"response":{"code":200}}]}`
-	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
-		t.Fatal(err)
+	cases := map[string]string{
+		"ext.yaml": "x-defaults:\n  code: 200\ncoats:\n  - name: a\n    request:\n      uri: /a\n    response:\n      code: 200\n",
+		"ext.json": `{"x-defaults":{"code":200},"coats":[{"name":"a","request":{"uri":"/a"},"response":{"code":200}}]}`,
 	}
+	for name, body := range cases {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
 
-	if _, err := coat.ParseFile(path); err == nil {
-		t.Fatal("expected a JSON x- key to be rejected as an unknown field")
-	} else if !strings.Contains(err.Error(), "x-defaults") {
-		t.Fatalf("parse error should name the offending field, got: %v", err)
+		if _, err := coat.ParseFile(path); err == nil {
+			t.Errorf("%s: expected a top-level x- key to be rejected as an unknown field", name)
+		} else if !strings.Contains(err.Error(), "x-defaults") {
+			t.Errorf("%s: parse error should name the offending field, got: %v", name, err)
+		}
 	}
 }
 
-func TestParseFile_AllowsTopLevelExtensionKeys(t *testing.T) {
-	// Strict decoding must not break the anchor-holder idiom: a top-level x-
-	// key exists purely to carry a YAML anchor that coats then merge in. Merge
-	// keys always worked; it was the key holding the anchor that stopped
-	// parsing. Any other unknown key is still an error.
+func TestParseFile_SharesResponseDefaultsViaInlineAnchor(t *testing.T) {
+	// Anchoring on the first coat that uses the values, rather than on a
+	// top-level holder key, shares response defaults without any key outside
+	// the schema. This is the supported way to avoid repeating a response, so
+	// it asserts the merged values -- not merely that the file parses.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "anchors.yaml")
-	body := `x-defaults: &defaults
-  code: 200
-  headers:
-    Content-Type: application/json
-coats:
-  - name: uses-anchor
+	body := `coats:
+  - name: first
     request:
-      uri: /api/users
+      uri: /a
+    response: &defaults
+      code: 200
+      headers:
+        Content-Type: application/json
+  - name: second
+    request:
+      uri: /b
     response:
       <<: *defaults
+  - name: third
+    request:
+      uri: /c
+    response:
+      <<: *defaults
+      code: 201
 `
 	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 		t.Fatal(err)
@@ -695,12 +709,19 @@ coats:
 
 	f, err := coat.ParseFile(path)
 	if err != nil {
-		t.Fatalf("a top-level x- key holding an anchor must parse, got: %v", err)
+		t.Fatalf("merging an inline anchor must parse, got: %v", err)
 	}
-	if len(f.Coats) != 1 {
-		t.Fatalf("expected 1 coat, got %d", len(f.Coats))
+	if len(f.Coats) != 3 {
+		t.Fatalf("expected 3 coats, got %d", len(f.Coats))
 	}
-	if got := f.Coats[0].Response.Code; got != 200 {
-		t.Fatalf("merged anchor should set code 200, got %d", got)
+
+	wantCodes := []int{200, 200, 201}
+	for i, want := range wantCodes {
+		if got := f.Coats[i].Response.Code; got != want {
+			t.Errorf("coat %d: expected code %d, got %d", i, want, got)
+		}
+		if got := f.Coats[i].Response.Headers["Content-Type"]; got != "application/json" {
+			t.Errorf("coat %d: expected merged Content-Type application/json, got %q", i, got)
+		}
 	}
 }

--- a/internal/coat/parse_test.go
+++ b/internal/coat/parse_test.go
@@ -2,8 +2,8 @@ package coat_test
 
 import (
 	"os"
-	"strings"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/yesdevnull/trenchcoat/internal/coat"

--- a/internal/coat/parse_test.go
+++ b/internal/coat/parse_test.go
@@ -495,10 +495,10 @@ func assertEqual[T comparable](t *testing.T, field string, expected, actual T) {
 }
 
 func TestParseFile_UnknownFieldIsAnError(t *testing.T) {
-	// coatfile.schema.json sets additionalProperties: false throughout, but the
-	// parsers discarded unknown keys, so a typo validated clean and quietly
-	// changed behaviour: 'mehtod: POST' left the coat defaulting to GET, so the
-	// intended POSTs 404'd and unintended GETs matched.
+	// coatfile.schema.json sets additionalProperties: false throughout, so a
+	// misspelt key must be an error rather than a silent default: 'mehtod: POST'
+	// leaves the coat on GET, so the POSTs it was written for 404 while
+	// unintended GETs match it.
 	dir := t.TempDir()
 
 	yamlPath := filepath.Join(dir, "typo.yaml")

--- a/internal/coat/parse_test.go
+++ b/internal/coat/parse_test.go
@@ -573,22 +573,54 @@ func TestParseFile_KnownFieldsStillParse(t *testing.T) {
 }
 
 func TestParseFile_RejectsTrailingContent(t *testing.T) {
-	// json.Decoder reads one value and stops, unlike json.Unmarshal which
-	// required the whole input to be a single document. Without an explicit
-	// check, a second appended object or trailing garbage loads silently and
-	// half the file's coats simply do not exist.
+	// Both decoders read one document and stop, unlike json.Unmarshal and
+	// yaml.Unmarshal which took the whole input. Without an explicit check, a
+	// second document or trailing garbage loads silently and half the file's
+	// coats simply do not exist.
 	dir := t.TempDir()
 
 	for name, body := range map[string]string{
 		"second-document.json":  `{"coats":[{"name":"a","request":{"uri":"/a"},"response":{"code":200}}]}{"coats":[]}`,
 		"trailing-garbage.json": `{"coats":[{"name":"a","request":{"uri":"/a"},"response":{"code":200}}]} garbage`,
+		"second-document.yaml":  "coats:\n  - name: a\n    request:\n      uri: /a\n    response:\n      code: 200\n---\ncoats:\n  - name: b\n    request:\n      uri: /b\n    response:\n      code: 200\n",
+		"trailing-garbage.yaml": "coats:\n  - name: a\n    request:\n      uri: /a\n    response:\n      code: 200\n--- }{ invalid\n",
 	} {
 		path := filepath.Join(dir, name)
 		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
 			t.Fatal(err)
 		}
 		if _, err := coat.ParseFile(path); err == nil {
-			t.Errorf("%s: expected an error for content after the JSON document", name)
+			t.Errorf("%s: expected an error for content after the first document", name)
+		}
+	}
+}
+
+func TestParseFile_AcceptsYAMLDocumentMarkers(t *testing.T) {
+	// Rejecting a second document must not reject the markers a single-document
+	// file may carry: a leading '---', a trailing '---' or '...' terminator, and
+	// a trailing comment are all one document as far as the file's author is
+	// concerned. A bare '---' at the end decodes as a null document, so nothing
+	// but a null one is tolerated after the first.
+	dir := t.TempDir()
+
+	coats := "coats:\n  - name: a\n    request:\n      uri: /a\n    response:\n      code: 200\n"
+	for name, body := range map[string]string{
+		"leading.yaml":          "---\n" + coats,
+		"trailing-marker.yaml":  coats + "---\n",
+		"document-end.yaml":     coats + "...\n",
+		"trailing-comment.yaml": coats + "# nothing more\n",
+	} {
+		path := filepath.Join(dir, name)
+		if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+			t.Fatal(err)
+		}
+		f, err := coat.ParseFile(path)
+		if err != nil {
+			t.Errorf("%s: expected no error, got %v", name, err)
+			continue
+		}
+		if len(f.Coats) != 1 {
+			t.Errorf("%s: expected 1 coat, got %d", name, len(f.Coats))
 		}
 	}
 }

--- a/internal/coat/parse_test.go
+++ b/internal/coat/parse_test.go
@@ -652,6 +652,25 @@ func TestParseFile_EmptyFileIsNotAnError(t *testing.T) {
 	}
 }
 
+func TestParseFile_RejectsExtensionKeysInJSON(t *testing.T) {
+	// The x- allowance is scoped to YAML, where it exists to carry an anchor.
+	// JSON has no anchors and so no use for it, and Extensions is json:"-" so a
+	// JSON x- key is an unknown field like any other. Pinned because the
+	// shipped schema and the documentation have both claimed otherwise.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ext.json")
+	body := `{"x-defaults":{"code":200},"coats":[{"name":"a","request":{"uri":"/a"},"response":{"code":200}}]}`
+	if err := os.WriteFile(path, []byte(body), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := coat.ParseFile(path); err == nil {
+		t.Fatal("expected a JSON x- key to be rejected as an unknown field")
+	} else if !strings.Contains(err.Error(), "x-defaults") {
+		t.Fatalf("parse error should name the offending field, got: %v", err)
+	}
+}
+
 func TestParseFile_AllowsTopLevelExtensionKeys(t *testing.T) {
 	// Strict decoding must not break the anchor-holder idiom: a top-level x-
 	// key exists purely to carry a YAML anchor that coats then merge in. Merge

--- a/internal/coat/types.go
+++ b/internal/coat/types.go
@@ -10,6 +10,9 @@ type File struct {
 	// names beginning "x-" are permitted, and nothing reads them: they exist so
 	// a coat file can hold a YAML anchor for coats to merge in, which strict
 	// decoding would otherwise reject. See parse.go.
+	//
+	// json:"-" scopes that to YAML: JSON has no anchors, so a JSON x- key is an
+	// unknown field like any other.
 	Extensions map[string]any `yaml:",inline" json:"-"`
 }
 

--- a/internal/coat/types.go
+++ b/internal/coat/types.go
@@ -5,15 +5,6 @@ package coat
 // File represents the top-level structure of a coat file.
 type File struct {
 	Coats []Coat `yaml:"coats" json:"coats"`
-
-	// Extensions collects top-level keys that are not part of the schema. Only
-	// names beginning "x-" are permitted, and nothing reads them: they exist so
-	// a coat file can hold a YAML anchor for coats to merge in, which strict
-	// decoding would otherwise reject. See parse.go.
-	//
-	// json:"-" scopes that to YAML: JSON has no anchors, so a JSON x- key is an
-	// unknown field like any other.
-	Extensions map[string]any `yaml:",inline" json:"-"`
 }
 
 // Coat is an individual request/response mock definition.

--- a/internal/coat/types.go
+++ b/internal/coat/types.go
@@ -5,6 +5,12 @@ package coat
 // File represents the top-level structure of a coat file.
 type File struct {
 	Coats []Coat `yaml:"coats" json:"coats"`
+
+	// Extensions collects top-level keys that are not part of the schema. Only
+	// names beginning "x-" are permitted, and nothing reads them: they exist so
+	// a coat file can hold a YAML anchor for coats to merge in, which strict
+	// decoding would otherwise reject. See parse.go.
+	Extensions map[string]any `yaml:",inline" json:"-"`
 }
 
 // Coat is an individual request/response mock definition.

--- a/internal/coat/validate.go
+++ b/internal/coat/validate.go
@@ -12,6 +12,17 @@ import (
 // MaxDelayMs is the maximum allowed value for delay_ms (60 seconds).
 const MaxDelayMs = 60000
 
+// AnchorRegexURI wraps a regex URI pattern so it must match the whole path.
+//
+// The group is not optional. Concatenating "^" and "$" onto a pattern with a
+// top-level alternation yields "^/users|/accounts$", which regexp reads as
+// "(^/users)|(/accounts$)": each alternative keeps one anchor and the coat
+// matches paths it never claimed. The matcher and the validator must both use
+// this, or validate accepts patterns the matcher rejects and vice versa.
+func AnchorRegexURI(pattern string) string {
+	return "^(?:" + pattern + ")$"
+}
+
 // GlobMetacharacters are the characters whose presence makes a request URI a
 // glob rather than an exact path. The matcher's classifier and this package's
 // validation must agree on this set: if validation used a narrower set it would
@@ -97,7 +108,7 @@ func validateCoat(index int, c Coat) []*ValidationError {
 	// Validate regex URI syntax.
 	if strings.HasPrefix(c.Request.URI, "~/") {
 		pattern := strings.TrimPrefix(c.Request.URI, "~")
-		if _, err := regexp.Compile("^" + pattern + "$"); err != nil {
+		if _, err := regexp.Compile(AnchorRegexURI(pattern)); err != nil {
 			errs = append(errs, mkErr(fmt.Sprintf("request.uri has invalid regex %q: %v", c.Request.URI, err)))
 		}
 	} else if strings.ContainsAny(c.Request.URI, GlobMetacharacters) {

--- a/internal/coat/validate.go
+++ b/internal/coat/validate.go
@@ -5,10 +5,18 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/bmatcuk/doublestar/v4"
 )
 
 // MaxDelayMs is the maximum allowed value for delay_ms (60 seconds).
 const MaxDelayMs = 60000
+
+// GlobMetacharacters are the characters whose presence makes a request URI a
+// glob rather than an exact path. The matcher's classifier and this package's
+// validation must agree on this set: if validation used a narrower set it would
+// accept URIs the matcher then treats as globs and can never match.
+const GlobMetacharacters = "*?["
 
 // ValidationError represents a single validation error for a coat.
 type ValidationError struct {
@@ -91,6 +99,13 @@ func validateCoat(index int, c Coat) []*ValidationError {
 		pattern := strings.TrimPrefix(c.Request.URI, "~")
 		if _, err := regexp.Compile("^" + pattern + "$"); err != nil {
 			errs = append(errs, mkErr(fmt.Sprintf("request.uri has invalid regex %q: %v", c.Request.URI, err)))
+		}
+	} else if strings.ContainsAny(c.Request.URI, GlobMetacharacters) {
+		// The matcher classifies any URI containing a glob metacharacter as a
+		// glob. One that doublestar cannot compile matches nothing at all, so
+		// reject it here rather than let the coat sit dead in the file.
+		if !doublestar.ValidatePattern(c.Request.URI) {
+			errs = append(errs, mkErr(fmt.Sprintf("request.uri has invalid glob %q", c.Request.URI)))
 		}
 	}
 

--- a/internal/coat/validate_test.go
+++ b/internal/coat/validate_test.go
@@ -51,6 +51,51 @@ func TestValidate_InvalidRegexURI(t *testing.T) {
 
 // --- body_match validation ---
 
+func TestValidate_InvalidGlobURI(t *testing.T) {
+	// An unclosed '[' makes the URI a glob (the classifier triggers on '*?[')
+	// that doublestar cannot compile, so the coat silently never matches. The
+	// near-miss diagnostic for it reads "pattern X did not match X", which is
+	// baffling unless validation rejects it up front.
+	f := &File{
+		Coats: []Coat{
+			{
+				Name:     "bad-glob",
+				Request:  Request{URI: "/api/items[]"},
+				Response: &Response{Code: 200},
+			},
+		},
+	}
+
+	errs := Validate(f)
+	found := false
+	for _, e := range errs {
+		if strings.Contains(e.Message, "invalid glob") && strings.Contains(e.Message, "/api/items[]") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected an error naming the invalid glob pattern, got: %v", errs)
+	}
+}
+
+func TestValidate_ValidGlobURIsAccepted(t *testing.T) {
+	for _, uri := range []string{"/api/v1/users/*", "/api/**/posts/*", "/api/v?/users", "/api/items[abc]"} {
+		f := &File{
+			Coats: []Coat{
+				{
+					Name:     "good-glob",
+					Request:  Request{URI: uri},
+					Response: &Response{Code: 200},
+				},
+			},
+		}
+		if errs := Validate(f); len(errs) > 0 {
+			t.Fatalf("expected %q to validate, got: %v", uri, errs)
+		}
+	}
+}
+
 func TestValidate_BodyMatchWithoutBody(t *testing.T) {
 	f := &File{
 		Coats: []Coat{

--- a/internal/coat/validate_test.go
+++ b/internal/coat/validate_test.go
@@ -74,6 +74,90 @@ func TestValidate_BodyMatchWithoutBody(t *testing.T) {
 	}
 }
 
+// TestValidate_ResponseConstraints covers every error branch of
+// validateResponse. Two of these rules have no runtime backstop: the server
+// sizes its write timeout assuming delay_ms is capped, and it calls
+// rand.IntN(delay_jitter_ms), which panics on a negative value. Validation is
+// the only thing standing between a hand-edited coat file and that panic.
+func TestValidate_ResponseConstraints(t *testing.T) {
+	tests := []struct {
+		name     string
+		response Response
+		wantMsg  string
+	}{
+		{
+			name:     "absolute body_file",
+			response: Response{Code: 200, BodyFile: "/etc/passwd"},
+			wantMsg:  "'body_file' must not be an absolute path",
+		},
+		{
+			name:     "body_file escaping the coat directory",
+			response: Response{Code: 200, BodyFile: "../../escape.json"},
+			wantMsg:  "'body_file' must not contain '..' path components",
+		},
+		{
+			name:     "negative delay_ms",
+			response: Response{Code: 200, DelayMs: -1},
+			wantMsg:  "'delay_ms' must not be negative",
+		},
+		{
+			name:     "delay_ms above the cap",
+			response: Response{Code: 200, DelayMs: MaxDelayMs + 1},
+			wantMsg:  "'delay_ms' must not exceed 60000",
+		},
+		{
+			name:     "negative delay_jitter_ms",
+			response: Response{Code: 200, DelayJitterMs: -1},
+			wantMsg:  "'delay_jitter_ms' must not be negative",
+		},
+		{
+			name:     "delay_ms and delay_jitter_ms combined above the cap",
+			response: Response{Code: 200, DelayMs: 59000, DelayJitterMs: 2000},
+			wantMsg:  "combined 'delay_ms' and 'delay_jitter_ms' must not exceed 60000",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name+"/response", func(t *testing.T) {
+			resp := tt.response
+			f := &File{Coats: []Coat{{
+				Name:     "singular",
+				Request:  Request{URI: "/test"},
+				Response: &resp,
+			}}}
+			assertValidationError(t, Validate(f), "response: "+tt.wantMsg)
+		})
+
+		t.Run(tt.name+"/responses", func(t *testing.T) {
+			resp := tt.response
+			f := &File{Coats: []Coat{{
+				Name:      "plural",
+				Request:   Request{URI: "/test"},
+				Responses: []Response{{Code: 200}, resp},
+			}}}
+			assertValidationError(t, Validate(f), "responses[1]: "+tt.wantMsg)
+		})
+	}
+}
+
+// assertValidationError fails unless exactly the expected message is present,
+// so a test cannot pass on some unrelated error the coat also happens to have.
+func assertValidationError(t *testing.T, errs []*ValidationError, want string) {
+	t.Helper()
+
+	for _, e := range errs {
+		if e.Message == want {
+			return
+		}
+	}
+
+	got := make([]string, 0, len(errs))
+	for _, e := range errs {
+		got = append(got, e.Message)
+	}
+	t.Fatalf("expected validation error %q, got %v", want, got)
+}
+
 func TestValidate_BodyMatchInvalidValue(t *testing.T) {
 	body := "hello"
 	f := &File{

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -220,12 +220,17 @@ func resolveSequence(best *entry) (idx int, exhausted bool) {
 		seq = "cycle"
 	}
 
-	if seq == "once" && idx >= len(best.coat.Responses) {
-		return -1, true
-	}
-
-	if seq == "cycle" {
-		idx = idx % len(best.coat.Responses)
+	if seq == "once" {
+		if idx >= len(best.coat.Responses) {
+			return -1, true
+		}
+	} else {
+		// Anything that is not "once" cycles. Validation restricts this field to
+		// "once" and "cycle", but only for coats loaded from a file: the
+		// programmatic API accepts a Coat as given, so an unrecognised value
+		// such as "Once" must not walk the counter off the end of Responses and
+		// panic the server that indexes it.
+		idx %= len(best.coat.Responses)
 	}
 
 	best.seqCounter++

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -62,6 +62,12 @@ type MatchResult struct {
 // Matcher matches HTTP requests to coat definitions.
 type Matcher struct {
 	entries []*entry
+
+	// globCache memoises compiled header/query/body glob patterns. It belongs to
+	// the Matcher rather than the package so a hot reload discards the previous
+	// generation's patterns along with its coats; a package-level cache would
+	// accumulate every pattern ever loaded for the life of the process.
+	globCache sync.Map // pattern string -> *regexp.Regexp
 }
 
 // resolvedName returns the coat's name, or a fallback like "coat[N]" if unnamed.
@@ -257,13 +263,13 @@ func (m *Matcher) findCandidates(req *http.Request, getBody func() (string, erro
 		if !matchesURI(e, req.URL.Path) {
 			continue
 		}
-		if !matchesHeaders(e, req.Header) {
+		if !m.matchesHeaders(e, req.Header) {
 			continue
 		}
-		if !matchesQuery(e, req.URL.RawQuery, req.URL.Query()) {
+		if !m.matchesQuery(e, req.URL.RawQuery, req.URL.Query()) {
 			continue
 		}
-		if !matchesBody(e, getBody) {
+		if !m.matchesBody(e, getBody) {
 			continue
 		}
 
@@ -365,8 +371,8 @@ func (m *Matcher) MatchVerbose(req *http.Request) (*MatchResult, []Mismatch) {
 			})
 			continue
 		}
-		if !matchesHeaders(e, req.Header) {
-			reason := diagnoseHeaderMismatch(e, req.Header)
+		if !m.matchesHeaders(e, req.Header) {
+			reason := m.diagnoseHeaderMismatch(e, req.Header)
 			mismatches = append(mismatches, Mismatch{
 				CoatName: name,
 				Reason:   reason,
@@ -374,8 +380,8 @@ func (m *Matcher) MatchVerbose(req *http.Request) (*MatchResult, []Mismatch) {
 			})
 			continue
 		}
-		if !matchesQuery(e, req.URL.RawQuery, req.URL.Query()) {
-			reason := diagnoseQueryMismatch(e, req.URL.RawQuery, req.URL.Query())
+		if !m.matchesQuery(e, req.URL.RawQuery, req.URL.Query()) {
+			reason := m.diagnoseQueryMismatch(e, req.URL.RawQuery, req.URL.Query())
 			mismatches = append(mismatches, Mismatch{
 				CoatName: name,
 				Reason:   reason,
@@ -401,7 +407,7 @@ func (m *Matcher) MatchVerbose(req *http.Request) (*MatchResult, []Mismatch) {
 	return nil, mismatches
 }
 
-func diagnoseHeaderMismatch(e *entry, reqHeaders http.Header) string {
+func (m *Matcher) diagnoseHeaderMismatch(e *entry, reqHeaders http.Header) string {
 	for key, pattern := range e.coat.Request.Headers {
 		values := reqHeaders.Values(key)
 		if len(values) == 0 {
@@ -409,7 +415,7 @@ func diagnoseHeaderMismatch(e *entry, reqHeaders http.Header) string {
 		}
 		matched := false
 		for _, v := range values {
-			if globMatch(pattern, v) {
+			if m.globMatch(pattern, v) {
 				matched = true
 				break
 			}
@@ -421,7 +427,7 @@ func diagnoseHeaderMismatch(e *entry, reqHeaders http.Header) string {
 	return "header mismatch"
 }
 
-func diagnoseQueryMismatch(e *entry, rawQuery string, queryValues map[string][]string) string {
+func (m *Matcher) diagnoseQueryMismatch(e *entry, rawQuery string, queryValues map[string][]string) string {
 	q := e.coat.Request.Query
 	if q == nil {
 		return "query mismatch"
@@ -437,7 +443,7 @@ func diagnoseQueryMismatch(e *entry, rawQuery string, queryValues map[string][]s
 			}
 			matched := false
 			for _, v := range values {
-				if globMatch(pattern, v) {
+				if m.globMatch(pattern, v) {
 					matched = true
 					break
 				}
@@ -507,7 +513,7 @@ func matchesURI(e *entry, reqPath string) bool {
 	return false
 }
 
-func matchesHeaders(e *entry, reqHeaders http.Header) bool {
+func (m *Matcher) matchesHeaders(e *entry, reqHeaders http.Header) bool {
 	for key, pattern := range e.coat.Request.Headers {
 		values := reqHeaders.Values(key)
 		if len(values) == 0 {
@@ -516,7 +522,7 @@ func matchesHeaders(e *entry, reqHeaders http.Header) bool {
 		// Check if any header value matches the glob pattern.
 		matched := false
 		for _, v := range values {
-			if globMatch(pattern, v) {
+			if m.globMatch(pattern, v) {
 				matched = true
 				break
 			}
@@ -528,7 +534,7 @@ func matchesHeaders(e *entry, reqHeaders http.Header) bool {
 	return true
 }
 
-func matchesQuery(e *entry, rawQuery string, queryValues map[string][]string) bool {
+func (m *Matcher) matchesQuery(e *entry, rawQuery string, queryValues map[string][]string) bool {
 	q := e.coat.Request.Query
 	if q == nil {
 		return true
@@ -548,7 +554,7 @@ func matchesQuery(e *entry, rawQuery string, queryValues map[string][]string) bo
 			}
 			matched := false
 			for _, v := range values {
-				if globMatch(pattern, v) {
+				if m.globMatch(pattern, v) {
 					matched = true
 					break
 				}
@@ -562,7 +568,7 @@ func matchesQuery(e *entry, rawQuery string, queryValues map[string][]string) bo
 	return true
 }
 
-func matchesBody(e *entry, getBody func() (string, error)) bool {
+func (m *Matcher) matchesBody(e *entry, getBody func() (string, error)) bool {
 	if e.coat.Request.Body == nil {
 		return true // No body constraint — matches anything.
 	}
@@ -572,7 +578,7 @@ func matchesBody(e *entry, getBody func() (string, error)) bool {
 	}
 	switch e.coat.Request.BodyMatch {
 	case "glob":
-		return globMatch(*e.coat.Request.Body, body)
+		return m.globMatch(*e.coat.Request.Body, body)
 	case "contains":
 		return strings.Contains(body, *e.coat.Request.Body)
 	case "regex":
@@ -585,10 +591,6 @@ func matchesBody(e *entry, getBody func() (string, error)) bool {
 	}
 }
 
-// globCache memoises compiled header/query/body glob patterns. Patterns come
-// from the loaded coats, so the set is small and fixed for a server's lifetime.
-var globCache sync.Map // pattern string -> *regexp.Regexp
-
 // globMatch performs glob matching on a string value, where * matches any
 // sequence of characters and ? matches any single character. Every other
 // character, '[' included, matches itself.
@@ -597,12 +599,12 @@ var globCache sync.Map // pattern string -> *regexp.Regexp
 // which are URI paths, so * deliberately spans '/': a coat asking for
 // Content-Type: "*" expects to match "application/json". URI globbing is
 // separate and stays segment-aware, via doublestar in matchesURI.
-func globMatch(pattern, value string) bool {
-	return compileGlob(pattern).MatchString(value)
+func (m *Matcher) globMatch(pattern, value string) bool {
+	return m.compileGlob(pattern).MatchString(value)
 }
 
-func compileGlob(pattern string) *regexp.Regexp {
-	if cached, ok := globCache.Load(pattern); ok {
+func (m *Matcher) compileGlob(pattern string) *regexp.Regexp {
+	if cached, ok := m.globCache.Load(pattern); ok {
 		return cached.(*regexp.Regexp)
 	}
 
@@ -624,6 +626,6 @@ func compileGlob(pattern string) *regexp.Regexp {
 	// Every component is either a metacharacter this function emitted or a
 	// QuoteMeta'd literal, so the result always compiles.
 	re := regexp.MustCompile(b.String())
-	globCache.Store(pattern, re)
+	m.globCache.Store(pattern, re)
 	return re
 }

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -85,7 +85,7 @@ func New(coats []coat.Coat) *Matcher {
 		if strings.HasPrefix(c.Request.URI, "~/") {
 			e.uriType = uriRegex
 			pattern := strings.TrimPrefix(c.Request.URI, "~")
-			re, err := regexp.Compile("^" + pattern + "$")
+			re, err := regexp.Compile(coat.AnchorRegexURI(pattern))
 			if err == nil {
 				e.regex = re
 			}

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"path"
 	"regexp"
 	"sort"
 	"strings"
@@ -576,10 +575,45 @@ func matchesBody(e *entry, getBody func() (string, error)) bool {
 	}
 }
 
-// globMatch performs simple glob matching on a string value.
-// Uses path.Match which supports * (any characters within a segment) and ? (single character).
-// This is used for header values, query values, and body matching — not URI paths.
+// globCache memoises compiled header/query/body glob patterns. Patterns come
+// from the loaded coats, so the set is small and fixed for a server's lifetime.
+var globCache sync.Map // pattern string -> *regexp.Regexp
+
+// globMatch performs glob matching on a string value, where * matches any
+// sequence of characters and ? matches any single character. Every other
+// character, '[' included, matches itself.
+//
+// This is used for header values, query values and body matching — none of
+// which are URI paths, so * deliberately spans '/': a coat asking for
+// Content-Type: "*" expects to match "application/json". URI globbing is
+// separate and stays segment-aware, via doublestar in matchesURI.
 func globMatch(pattern, value string) bool {
-	matched, _ := path.Match(pattern, value)
-	return matched
+	return compileGlob(pattern).MatchString(value)
+}
+
+func compileGlob(pattern string) *regexp.Regexp {
+	if cached, ok := globCache.Load(pattern); ok {
+		return cached.(*regexp.Regexp)
+	}
+
+	// (?s) so '.' spans newlines, which multi-line bodies contain.
+	var b strings.Builder
+	b.WriteString("(?s)^")
+	for _, r := range pattern {
+		switch r {
+		case '*':
+			b.WriteString(".*")
+		case '?':
+			b.WriteString(".")
+		default:
+			b.WriteString(regexp.QuoteMeta(string(r)))
+		}
+	}
+	b.WriteString("$")
+
+	// Every component is either a metacharacter this function emitted or a
+	// QuoteMeta'd literal, so the result always compiles.
+	re := regexp.MustCompile(b.String())
+	globCache.Store(pattern, re)
+	return re
 }

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -93,9 +93,14 @@ func New(coats []coat.Coat) *Matcher {
 			// nil so matchesURI will never match it.
 		} else if strings.ContainsAny(c.Request.URI, coat.GlobMetacharacters) {
 			e.uriType = uriGlob
-			// Compute literal prefix length (characters before first wildcard).
+			// Compute literal prefix length (characters before the first glob
+			// metacharacter). This must stop at every character that makes the
+			// URI a glob, '[' included: a character class is not literal, and
+			// counting it as such credits the pattern with a longer literal
+			// prefix than it has, letting it outrank globs that really are more
+			// specific.
 			for _, ch := range c.Request.URI {
-				if ch == '*' || ch == '?' {
+				if strings.ContainsRune(coat.GlobMetacharacters, ch) {
 					break
 				}
 				e.literalLen++

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -91,7 +91,7 @@ func New(coats []coat.Coat) *Matcher {
 			}
 			// Invalid regex: keep the entry (for diagnostics) but leave e.regex
 			// nil so matchesURI will never match it.
-		} else if strings.ContainsAny(c.Request.URI, "*?[") {
+		} else if strings.ContainsAny(c.Request.URI, coat.GlobMetacharacters) {
 			e.uriType = uriGlob
 			// Compute literal prefix length (characters before first wildcard).
 			for _, ch := range c.Request.URI {

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -319,6 +319,118 @@ func TestMatch_HeaderGlob(t *testing.T) {
 	}
 }
 
+// Header, query and body values are not paths, so a glob '*' must span '/'.
+// Segment-aware globbing belongs to URI matching alone.
+
+func TestMatch_HeaderGlobMatchesAcrossSlashes(t *testing.T) {
+	coats := []coat.Coat{
+		{
+			Name: "any-content-type",
+			Request: coat.Request{
+				Method:  "POST",
+				URI:     "/test",
+				Headers: map[string]string{"Content-Type": "*"},
+			},
+			Response: &coat.Response{Code: 200},
+		},
+	}
+	m := matcher.New(coats)
+
+	req := newRequest(t, "POST", "/test", map[string]string{
+		"Content-Type": "application/json",
+	})
+	if m.Match(req) == nil {
+		t.Fatal(`expected match — header glob "*" must match "application/json"`)
+	}
+}
+
+func TestMatch_QueryGlobMatchesAcrossSlashes(t *testing.T) {
+	coats := []coat.Coat{
+		{
+			Name: "any-redirect",
+			Request: coat.Request{
+				Method: "GET",
+				URI:    "/login",
+				Query:  &coat.QueryField{Map: map[string]string{"redirect": "*"}},
+			},
+			Response: &coat.Response{Code: 200},
+		},
+	}
+	m := matcher.New(coats)
+
+	req := newRequest(t, "GET", "/login?redirect=/home/dash", nil)
+	if m.Match(req) == nil {
+		t.Fatal(`expected match — query glob "*" must match "/home/dash"`)
+	}
+}
+
+func TestMatch_BodyGlobMatchesAcrossSlashes(t *testing.T) {
+	coats := []coat.Coat{
+		{
+			Name: "any-url-body",
+			Request: coat.Request{
+				Method:    "POST",
+				URI:       "/hook",
+				Body:      coat.StringPtr(`{"url": "*"}`),
+				BodyMatch: "glob",
+			},
+			Response: &coat.Response{Code: 200},
+		},
+	}
+	m := matcher.New(coats)
+
+	req := newRequestWithBody(t, "POST", "/hook", nil, `{"url": "https://example.com/a/b"}`)
+	if m.Match(req) == nil {
+		t.Fatal(`expected match — body glob "*" must match a URL containing slashes`)
+	}
+}
+
+func TestMatch_BodyGlobMatchesAcrossNewlines(t *testing.T) {
+	// Bodies are frequently multi-line; a glob that stops at '\n' would be as
+	// surprising as one that stops at '/'.
+	coats := []coat.Coat{
+		{
+			Name: "any-multiline-body",
+			Request: coat.Request{
+				Method:    "POST",
+				URI:       "/hook",
+				Body:      coat.StringPtr(`{*}`),
+				BodyMatch: "glob",
+			},
+			Response: &coat.Response{Code: 200},
+		},
+	}
+	m := matcher.New(coats)
+
+	req := newRequestWithBody(t, "POST", "/hook", nil, "{\n  \"a\": 1\n}")
+	if m.Match(req) == nil {
+		t.Fatal(`expected match — body glob "*" must span newlines`)
+	}
+}
+
+func TestMatch_HeaderGlobBracketIsLiteral(t *testing.T) {
+	// path.Match returned ErrBadPattern for an unclosed '[' and the error was
+	// discarded, so such a coat could never match anything. With only * and ?
+	// as metacharacters, '[' is an ordinary character.
+	coats := []coat.Coat{
+		{
+			Name: "bracket-token",
+			Request: coat.Request{
+				Method:  "GET",
+				URI:     "/test",
+				Headers: map[string]string{"X-Token": "abc[*"},
+			},
+			Response: &coat.Response{Code: 200},
+		},
+	}
+	m := matcher.New(coats)
+
+	req := newRequest(t, "GET", "/test", map[string]string{"X-Token": "abc[def"})
+	if m.Match(req) == nil {
+		t.Fatal(`expected match — "abc[*" should match the literal prefix "abc["`)
+	}
+}
+
 // --- Query matching (map form) ---
 
 func TestMatch_QueryMap(t *testing.T) {

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -1603,7 +1603,7 @@ func TestMatchVerbose_NearMissDiagnostics(t *testing.T) {
 				Response: &coat.Response{Code: 200},
 			},
 			request: newRequest(t, "GET", "/search?page=2", nil),
-			want:    "page",
+			want:    `page=2 did not match pattern "1"`,
 		},
 		{
 			name: "raw query string does not match",

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -435,9 +435,8 @@ func TestMatch_BodyGlobMatchesAcrossNewlines(t *testing.T) {
 }
 
 func TestMatch_HeaderGlobBracketIsLiteral(t *testing.T) {
-	// path.Match returned ErrBadPattern for an unclosed '[' and the error was
-	// discarded, so such a coat could never match anything. With only * and ?
-	// as metacharacters, '[' is an ordinary character.
+	// With only * and ? as metacharacters, '[' is an ordinary character, so a
+	// pattern containing one matches it literally rather than never matching.
 	coats := []coat.Coat{
 		{
 			Name: "bracket-token",
@@ -1510,10 +1509,9 @@ func assertEqual[T comparable](t *testing.T, field string, expected, actual T) {
 }
 
 func TestMatch_GlobPrecedence_BracketIsNotLiteralPrefix(t *testing.T) {
-	// '[' makes a URI a glob, but the literal-prefix calculation stopped only at
-	// '*' and '?'. A bracketed pattern was therefore credited with a literal
-	// prefix running to the end of the string, and outranked a glob whose
-	// literal prefix is genuinely longer.
+	// Glob precedence is decided by literal prefix length, and a character class
+	// is not literal: counting it as such credits a pattern with more literal
+	// prefix than it has.
 	//
 	// "/api/[ij]tems/detail" has a real literal prefix of "/api/" (5), while
 	// "/api/items/*" has "/api/items/" (11), so the latter is the more specific

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -1082,22 +1082,26 @@ func TestMatchBodyIOError(t *testing.T) {
 func TestMatch_BodyExceedsMaxSize_NoMatch(t *testing.T) {
 	const maxBodyMatchSize = 1 << 20 // 1 MiB — mirrors the constant in matcher.go
 
+	// The coat constrains the body to exactly the bytes the request will send,
+	// so content is identical and the size cap is the only thing that can
+	// prevent a match. Constraining it to a different string instead would make
+	// this test pass on the content mismatch alone, proving nothing about the
+	// cap — it would stay green with the oversized-body branch deleted.
+	oversized := strings.Repeat("x", maxBodyMatchSize+1)
+
 	coats := []coat.Coat{
 		{
 			Name: "body-match",
 			Request: coat.Request{
 				Method: "POST",
 				URI:    "/upload",
-				Body:   coat.StringPtr("test"),
+				Body:   coat.StringPtr(oversized),
 			},
 			Response: &coat.Response{Code: 200},
 		},
 	}
 	m := matcher.New(coats)
 
-	// A body larger than maxBodyMatchSize should NOT match because the matcher
-	// treats oversized bodies as a read error for body-constrained coats.
-	oversized := strings.Repeat("x", maxBodyMatchSize+1)
 	req := newRequestWithBody(t, "POST", "/upload", nil, oversized)
 	result := m.Match(req)
 	if result != nil {

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -249,6 +249,32 @@ func TestMatch_RegexURI(t *testing.T) {
 	}
 }
 
+func TestMatch_RegexURIAlternationIsAnchored(t *testing.T) {
+	// Anchoring by concatenation gives "^/users|/accounts$", which regexp reads
+	// as "(^/users)|(/accounts$)" -- so each alternative keeps only one anchor
+	// and the coat fires on paths it was never meant to cover.
+	coats := []coat.Coat{
+		{
+			Name:     "regex-alternation",
+			Request:  coat.Request{Method: "GET", URI: `~/users|/accounts`},
+			Response: &coat.Response{Code: 200},
+		},
+	}
+	m := matcher.New(coats)
+
+	for _, uri := range []string{"/users", "/accounts"} {
+		if m.Match(newRequest(t, "GET", uri, nil)) == nil {
+			t.Fatalf("expected %q to match", uri)
+		}
+	}
+
+	for _, uri := range []string{"/users/secret/1", "/x/y/accounts"} {
+		if result := m.Match(newRequest(t, "GET", uri, nil)); result != nil {
+			t.Fatalf("expected no match for %q, but coat %q fired", uri, result.Name)
+		}
+	}
+}
+
 // --- Header matching ---
 
 func TestMatch_HeaderSubset(t *testing.T) {

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -1508,3 +1508,33 @@ func assertEqual[T comparable](t *testing.T, field string, expected, actual T) {
 		t.Errorf("%s: expected %v, got %v", field, expected, actual)
 	}
 }
+
+func TestMatch_GlobPrecedence_BracketIsNotLiteralPrefix(t *testing.T) {
+	// '[' makes a URI a glob, but the literal-prefix calculation stopped only at
+	// '*' and '?'. A bracketed pattern was therefore credited with a literal
+	// prefix running to the end of the string, and outranked a glob whose
+	// literal prefix is genuinely longer.
+	//
+	// "/api/[ij]tems/detail" has a real literal prefix of "/api/" (5), while
+	// "/api/items/*" has "/api/items/" (11), so the latter is the more specific
+	// match for /api/items/detail and must win.
+	coats := []coat.Coat{
+		{
+			Name:     "bracket-class",
+			Request:  coat.Request{Method: "GET", URI: "/api/[ij]tems/detail"},
+			Response: &coat.Response{Code: 200},
+		},
+		{
+			Name:     "longer-literal-prefix",
+			Request:  coat.Request{Method: "GET", URI: "/api/items/*"},
+			Response: &coat.Response{Code: 201},
+		},
+	}
+	m := matcher.New(coats)
+
+	result := m.Match(newRequest(t, "GET", "/api/items/detail", nil))
+	if result == nil {
+		t.Fatal("expected a match")
+	}
+	assertEqual(t, "name", "longer-literal-prefix", result.Name)
+}

--- a/internal/matcher/matcher_test.go
+++ b/internal/matcher/matcher_test.go
@@ -1536,3 +1536,122 @@ func TestMatch_GlobPrecedence_BracketIsNotLiteralPrefix(t *testing.T) {
 	}
 	assertEqual(t, "name", "longer-literal-prefix", result.Name)
 }
+
+func TestMatchVerbose_NearMissDiagnostics(t *testing.T) {
+	// The near-miss reason is what a user reads when a request they expected to
+	// match returns 404, so a wrong or vague one costs real debugging time. Each
+	// case names a distinct reason; only the missing-header branch was covered.
+	body := "hello"
+
+	tests := []struct {
+		name    string
+		coat    coat.Coat
+		request *http.Request
+		want    string
+	}{
+		{
+			name: "header absent from the request",
+			coat: coat.Coat{
+				Name: "needs-auth",
+				Request: coat.Request{
+					Method:  "GET",
+					URI:     "/test",
+					Headers: map[string]string{"Authorization": "Bearer *"},
+				},
+				Response: &coat.Response{Code: 200},
+			},
+			request: newRequest(t, "GET", "/test", nil),
+			want:    "missing header Authorization",
+		},
+		{
+			name: "header present but the value does not match",
+			coat: coat.Coat{
+				Name: "needs-bearer",
+				Request: coat.Request{
+					Method:  "GET",
+					URI:     "/test",
+					Headers: map[string]string{"Authorization": "Bearer *"},
+				},
+				Response: &coat.Response{Code: 200},
+			},
+			request: newRequest(t, "GET", "/test", map[string]string{"Authorization": "Basic abc"}),
+			want:    `Authorization value did not match pattern "Bearer *"`,
+		},
+		{
+			name: "query parameter absent",
+			coat: coat.Coat{
+				Name: "needs-page",
+				Request: coat.Request{
+					Method: "GET",
+					URI:    "/search",
+					Query:  &coat.QueryField{Map: map[string]string{"page": "1"}},
+				},
+				Response: &coat.Response{Code: 200},
+			},
+			request: newRequest(t, "GET", "/search", nil),
+			want:    "missing parameter page",
+		},
+		{
+			name: "query parameter present but the value does not match",
+			coat: coat.Coat{
+				Name: "needs-page-one",
+				Request: coat.Request{
+					Method: "GET",
+					URI:    "/search",
+					Query:  &coat.QueryField{Map: map[string]string{"page": "1"}},
+				},
+				Response: &coat.Response{Code: 200},
+			},
+			request: newRequest(t, "GET", "/search?page=2", nil),
+			want:    "page",
+		},
+		{
+			name: "raw query string does not match",
+			coat: coat.Coat{
+				Name: "needs-raw-query",
+				Request: coat.Request{
+					Method: "GET",
+					URI:    "/search",
+					Query:  &coat.QueryField{Raw: "page=1&limit=10"},
+				},
+				Response: &coat.Response{Code: 200},
+			},
+			request: newRequest(t, "GET", "/search?page=2", nil),
+			want:    "expected raw query",
+		},
+		{
+			name: "body does not match",
+			coat: coat.Coat{
+				Name: "needs-body",
+				Request: coat.Request{
+					Method: "POST",
+					URI:    "/submit",
+					Body:   &body,
+				},
+				Response: &coat.Response{Code: 200},
+			},
+			request: newRequestWithBody(t, "POST", "/submit", nil, "goodbye"),
+			want:    "body",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := matcher.New([]coat.Coat{tt.coat})
+
+			result, mismatches := m.MatchVerbose(tt.request)
+			if result != nil {
+				t.Fatalf("expected no match, got coat %q", result.Name)
+			}
+			if len(mismatches) == 0 {
+				t.Fatal("expected a near miss to be reported")
+			}
+			if mismatches[0].CoatName != tt.coat.Name {
+				t.Fatalf("near miss named coat %q, want %q", mismatches[0].CoatName, tt.coat.Name)
+			}
+			if !strings.Contains(mismatches[0].Reason, tt.want) {
+				t.Fatalf("near-miss reason %q does not mention %q", mismatches[0].Reason, tt.want)
+			}
+		})
+	}
+}

--- a/internal/matcher/sequence_test.go
+++ b/internal/matcher/sequence_test.go
@@ -214,11 +214,11 @@ func TestMatch_SingularResponse(t *testing.T) {
 }
 
 func TestResolveSequence_UnknownValueCycles(t *testing.T) {
-	// resolveSequence special-cases "once" and "cycle" and had no fallback, so
-	// any other value -- "Once" with the wrong case is the obvious way in --
-	// returned the raw counter and let it run past the end of Responses. The
-	// server then indexes that slice and panics. LoadPaths validates the value,
-	// but WithCoat/WithCoats do not, so a Go test can reach it.
+	// Anything that is not "once" must cycle. An unrecognised value -- "Once"
+	// with the wrong case is the obvious way in -- must not walk the counter past
+	// the end of Responses, which the server then indexes and panics on.
+	// LoadPaths validates the value, but WithCoat/WithCoats do not, so a Go test
+	// can reach it.
 	coats := []coat.Coat{
 		{
 			Name:      "bad-sequence",

--- a/internal/matcher/sequence_test.go
+++ b/internal/matcher/sequence_test.go
@@ -212,3 +212,34 @@ func TestMatch_SingularResponse(t *testing.T) {
 		t.Fatal("singular response should not be exhausted")
 	}
 }
+
+func TestResolveSequence_UnknownValueCycles(t *testing.T) {
+	// resolveSequence special-cases "once" and "cycle" and had no fallback, so
+	// any other value -- "Once" with the wrong case is the obvious way in --
+	// returned the raw counter and let it run past the end of Responses. The
+	// server then indexes that slice and panics. LoadPaths validates the value,
+	// but WithCoat/WithCoats do not, so a Go test can reach it.
+	coats := []coat.Coat{
+		{
+			Name:      "bad-sequence",
+			Request:   coat.Request{Method: "GET", URI: "/seq"},
+			Responses: []coat.Response{{Code: 200}, {Code: 201}},
+			Sequence:  "Once",
+		},
+	}
+	m := matcher.New(coats)
+
+	for i, want := range []int{0, 1, 0, 1} {
+		r := m.Match(newRequest(t, "GET", "/seq", nil))
+		if r == nil {
+			t.Fatalf("request %d: expected match", i)
+		}
+		if r.Exhausted {
+			t.Fatalf("request %d: an unrecognised sequence value must not exhaust", i)
+		}
+		if r.ResponseIdx != want {
+			t.Fatalf("request %d: got response index %d, want %d (in range of %d responses)",
+				i, r.ResponseIdx, want, len(coats[0].Responses))
+		}
+	}
+}

--- a/internal/proxy/capture_unix_test.go
+++ b/internal/proxy/capture_unix_test.go
@@ -47,10 +47,11 @@ func TestProxy_CaptureConcurrencyIsBounded(t *testing.T) {
 	writeDir := t.TempDir()
 
 	// The first `bound` captures block; with dedupe=overwrite each path maps to
-	// exactly one filename, so they can be picked in advance.
+	// exactly one filename, so the temp file each one writes can be picked in
+	// advance and a FIFO placed there.
 	blockedPaths := make([]string, 0, bound)
 	for i := range bound {
-		p := filepath.Join(writeDir, fmt.Sprintf("GET_b_%d_200.yaml", i))
+		p := blockingPathFor(writeDir, fmt.Sprintf("GET_b_%d_200.yaml", i))
 		if err := syscall.Mkfifo(p, 0600); err != nil {
 			t.Fatalf("failed to create fifo %s: %v", p, err)
 		}

--- a/internal/proxy/capture_unix_test.go
+++ b/internal/proxy/capture_unix_test.go
@@ -32,8 +32,8 @@ import (
 // Unix-only: it needs mkfifo. CI runs the suite on ubuntu-latest.
 func TestProxy_CaptureConcurrencyIsBounded(t *testing.T) {
 	const (
-		bound  = 20 // captureSem capacity
-		extra  = 5  // requests beyond the bound
+		bound  = proxy.CaptureConcurrency
+		extra  = 5 // requests beyond the bound
 		total  = bound + extra
 		settle = 250 * time.Millisecond
 	)
@@ -110,7 +110,7 @@ func TestProxy_CaptureConcurrencyIsBounded(t *testing.T) {
 				_ = resp.Body.Close()
 			}(i)
 		}
-		wg.Wait()
+		waitOrFail(t, &wg, 60*time.Second, "the request batch to finish")
 	}
 
 	// The blocking captures must be the ones holding the slots, so they go

--- a/internal/proxy/capture_unix_test.go
+++ b/internal/proxy/capture_unix_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"testing"
@@ -154,6 +155,106 @@ func TestProxy_CaptureConcurrencyIsBounded(t *testing.T) {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("%s never appeared after the blocked captures were released: %v", filepath.Base(path), err)
 		}
+	}
+}
+
+// TestProxy_CoatIsNotPublishedBeforeItsBodyFile pins the order in which a
+// capture publishes the two files it writes.
+//
+// A coat renamed into place ahead of the body_file it names is a valid-looking
+// coat pointing at a file that is not there: the server answers that route with
+// 500, and `serve --watch` on the capture directory reloads on the coat's
+// rename and starts doing so. If the process dies in that window the broken
+// coat is permanent, and under --dedupe skip permanently unrecoverable, because
+// captureExists then skips every future capture of that request.
+//
+// Timing cannot decide this -- the window is two writes apart on an idle
+// machine. The body write is blocked outright instead, with a FIFO at the temp
+// path it writes, and the coat must be absent for as long as the capture is
+// parked there.
+//
+// Unix-only: it needs mkfifo. CI runs the suite on ubuntu-latest.
+func TestProxy_CoatIsNotPublishedBeforeItsBodyFile(t *testing.T) {
+	const (
+		settle    = 250 * time.Millisecond
+		threshold = 16
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = fmt.Fprint(w, strings.Repeat("x", threshold*4))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+
+	// With dedupe=overwrite both names are fully determined by the request, so
+	// the FIFO can go where the body file's bytes actually land.
+	coatPath := filepath.Join(writeDir, "GET_doc_200.yaml")
+	bodyPath := filepath.Join(writeDir, "GET_doc_200_body.txt")
+	blockedBody := blockingPathFor(writeDir, "GET_doc_200_body.txt")
+	if err := syscall.Mkfifo(blockedBody, 0600); err != nil {
+		t.Fatalf("failed to create fifo at %s: %v", blockedBody, err)
+	}
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:       upstream.URL,
+		WriteDir:          writeDir,
+		StripHeaders:      []string{},
+		Dedupe:            "overwrite",
+		BodyFileThreshold: threshold,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+
+	// Cleanups run last-registered-first, so this pair releases the capture
+	// before the proxy is shut down.
+	t.Cleanup(func() { _ = p.Shutdown(10 * time.Second) })
+	drained := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-drained:
+			return
+		default:
+		}
+		// Best effort: O_NONBLOCK so this cannot hang if nothing is parked.
+		fifo, err := os.OpenFile(blockedBody, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, fifo)
+		_ = fifo.Close()
+	})
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Get(p.URL() + "/doc")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	// The capture is now parked writing the body file.
+	time.Sleep(settle)
+	if _, err := os.Stat(coatPath); err == nil {
+		t.Fatalf("%s was published while the body_file it names was still being written; a coat must never reach the directory ahead of the file it references",
+			filepath.Base(coatPath))
+	}
+
+	drainFifo(t, blockedBody, 30*time.Second)
+	close(drained)
+	p.WaitCaptures()
+
+	if _, err := os.Stat(bodyPath); err != nil {
+		t.Fatalf("the body file never appeared after the capture was released: %v", err)
+	}
+	if _, err := os.Stat(coatPath); err != nil {
+		t.Fatalf("the coat never appeared after the capture was released: %v", err)
 	}
 }
 

--- a/internal/proxy/capture_unix_test.go
+++ b/internal/proxy/capture_unix_test.go
@@ -143,12 +143,7 @@ func TestProxy_CaptureConcurrencyIsBounded(t *testing.T) {
 	// -- a FIFO with no writer attached yet -- so closing it would leave the
 	// capture still waiting for a reader that has already gone.
 	for _, path := range blockedPaths {
-		fifo, err := os.OpenFile(path, os.O_RDONLY, 0)
-		if err != nil {
-			t.Fatalf("failed to open fifo %s for reading: %v", path, err)
-		}
-		_, _ = io.Copy(io.Discard, fifo)
-		_ = fifo.Close()
+		drainFifo(t, path, 30*time.Second)
 	}
 	close(drained)
 
@@ -159,5 +154,36 @@ func TestProxy_CaptureConcurrencyIsBounded(t *testing.T) {
 		if _, err := os.Stat(path); err != nil {
 			t.Fatalf("%s never appeared after the blocked captures were released: %v", filepath.Base(path), err)
 		}
+	}
+}
+
+// drainFifo completes the rendezvous for a capture parked in open-for-write at
+// path, then reads what it writes.
+//
+// The open has to block -- an O_NONBLOCK reader on a FIFO with no writer
+// attached reads EOF straight away, so closing it would leave the capture
+// waiting for a reader that has already gone. A blocking open with nothing
+// parked there waits forever, though, which turns a broken assumption into a
+// hung package rather than a failed test: if the capture never arrives, this
+// says so instead.
+func drainFifo(t *testing.T, path string, within time.Duration) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fifo, err := os.OpenFile(path, os.O_RDONLY, 0)
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, fifo)
+		_ = fifo.Close()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(within):
+		t.Fatalf("no capture was parked writing %s after %s; the blocking path is not where this test expects it",
+			filepath.Base(path), within)
 	}
 }

--- a/internal/proxy/capture_unix_test.go
+++ b/internal/proxy/capture_unix_test.go
@@ -1,0 +1,162 @@
+//go:build unix
+
+package proxy_test
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/yesdevnull/trenchcoat/internal/proxy"
+)
+
+// TestProxy_CaptureConcurrencyIsBounded checks that captureSem actually bounds
+// concurrent capture writes.
+//
+// Counting the files a burst of requests produces cannot show this: the bound
+// is invisible once the captures have finished, so such a test passes with the
+// semaphore deleted. Blocking makes it visible. FIFOs are placed at the paths
+// the first 20 captures will write to, so those captures park in os.WriteFile
+// holding every semaphore slot. The remaining captures cannot start, and their
+// files must be absent for as long as the slots stay occupied. Free the slots
+// and they appear.
+//
+// Unix-only: it needs mkfifo. CI runs the suite on ubuntu-latest.
+func TestProxy_CaptureConcurrencyIsBounded(t *testing.T) {
+	const (
+		bound  = 20 // captureSem capacity
+		extra  = 5  // requests beyond the bound
+		total  = bound + extra
+		settle = 250 * time.Millisecond
+	)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+
+	// The first `bound` captures block; with dedupe=overwrite each path maps to
+	// exactly one filename, so they can be picked in advance.
+	blockedPaths := make([]string, 0, bound)
+	for i := range bound {
+		p := filepath.Join(writeDir, fmt.Sprintf("GET_b_%d_200.yaml", i))
+		if err := syscall.Mkfifo(p, 0600); err != nil {
+			t.Fatalf("failed to create fifo %s: %v", p, err)
+		}
+		blockedPaths = append(blockedPaths, p)
+	}
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	addr, err := p.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+
+	// Cleanups run last-registered-first, so this pair drains the FIFOs before
+	// shutting the proxy down -- otherwise Shutdown would sit out its whole
+	// capture drain waiting for captures that nothing has released.
+	t.Cleanup(func() { _ = p.Shutdown(10 * time.Second) })
+
+	drained := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-drained:
+			return
+		default:
+		}
+		// Best effort: O_NONBLOCK so this cannot hang if no capture is waiting.
+		for _, path := range blockedPaths {
+			fifo, err := os.OpenFile(path, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+			if err != nil {
+				continue
+			}
+			_, _ = io.Copy(io.Discard, fifo)
+			_ = fifo.Close()
+		}
+	})
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	request := func(from, to int) {
+		var wg sync.WaitGroup
+		for i := from; i < to; i++ {
+			wg.Add(1)
+			go func(n int) {
+				defer wg.Done()
+				resp, err := client.Get(fmt.Sprintf("http://%s/b/%d", addr, n))
+				if err != nil {
+					return
+				}
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}(i)
+		}
+		wg.Wait()
+	}
+
+	// The blocking captures must be the ones holding the slots, so they go
+	// first and are given time to reach their writes. Firing all the requests
+	// at once would leave it to the scheduler which captures take the slots,
+	// and a capture still queued for a slot is not parked in its FIFO -- which
+	// both weakens the assertion below and hangs the release loop, since it
+	// waits for a writer that has not arrived.
+	request(0, bound)
+	time.Sleep(settle)
+
+	// Every slot is now held by a capture blocked on its FIFO, so captures
+	// beyond the bound cannot run.
+	request(bound, total)
+	time.Sleep(settle)
+	for i := bound; i < total; i++ {
+		path := filepath.Join(writeDir, fmt.Sprintf("GET_b_%d_200.yaml", i))
+		if _, err := os.Stat(path); err == nil {
+			t.Fatalf("%s was written while all %d capture slots were blocked; captures are not bounded",
+				filepath.Base(path), bound)
+		}
+	}
+
+	// Releasing the blocked captures must let the rest through.
+	//
+	// A blocking open is required here. Each capture is parked in open-for-write
+	// waiting for a reader, and this open completes that rendezvous. Opening
+	// with O_NONBLOCK instead returns a descriptor that reads EOF straight away
+	// -- a FIFO with no writer attached yet -- so closing it would leave the
+	// capture still waiting for a reader that has already gone.
+	for _, path := range blockedPaths {
+		fifo, err := os.OpenFile(path, os.O_RDONLY, 0)
+		if err != nil {
+			t.Fatalf("failed to open fifo %s for reading: %v", path, err)
+		}
+		_, _ = io.Copy(io.Discard, fifo)
+		_ = fifo.Close()
+	}
+	close(drained)
+
+	p.WaitCaptures()
+
+	for i := bound; i < total; i++ {
+		path := filepath.Join(writeDir, fmt.Sprintf("GET_b_%d_200.yaml", i))
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("%s never appeared after the blocked captures were released: %v", filepath.Base(path), err)
+		}
+	}
+}

--- a/internal/proxy/locks_internal_test.go
+++ b/internal/proxy/locks_internal_test.go
@@ -1,0 +1,68 @@
+package proxy
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestProxy_ReleasesPerCaptureStateWhenCapturesFinish checks that the state a
+// capture keys by base name is gone once the capture has finished.
+//
+// Nothing about the captured files shows this: the entries are dead the moment
+// the capture completes, so a proxy that keeps them forever produces exactly the
+// same coat files. Only the maps themselves say whether they were reclaimed. A
+// proxy pointed at per-resource paths sees a distinct base name per resource,
+// and a leak there is one map entry plus one mutex per URL for the life of the
+// process, reclaimable only by restarting.
+//
+// It is an internal test because the maps are the subject: an assertion made
+// through the public API could not tell a reaped map from a retained one.
+func TestProxy_ReleasesPerCaptureStateWhenCapturesFinish(t *testing.T) {
+	const requests = 20
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = fmt.Fprint(w, "ok")
+	}))
+	defer upstream.Close()
+
+	p, err := New(Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     t.TempDir(),
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(10 * time.Second) })
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	for i := range requests {
+		resp, err := client.Get(fmt.Sprintf("%s/users/%d", p.URL(), i))
+		if err != nil {
+			t.Fatalf("request %d failed: %v", i, err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}
+	p.WaitCaptures()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.baseLocks) != 0 {
+		t.Errorf("baseLocks still holds %d entries after every capture finished; they are never reclaimed", len(p.baseLocks))
+	}
+	if len(p.inflight) != 0 {
+		t.Errorf("inflight still holds %d entries after every capture finished", len(p.inflight))
+	}
+}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -436,6 +436,10 @@ func (p *Proxy) shouldCapture(urlPath string) bool {
 	}
 	matched, err := doublestar.Match(p.config.Filter, urlPath)
 	if err != nil {
+		// Unreachable in practice: New rejects a pattern ValidatePattern turns
+		// down, so Match should never report a bad one. Kept as a backstop
+		// because the alternative is discarding the error, which would make the
+		// two APIs disagreeing look like an ordinary filter miss.
 		p.logger.Error("invalid capture filter pattern", "filter", p.config.Filter, "error", err)
 		return false
 	}

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -74,9 +74,10 @@ type Proxy struct {
 
 	nameTmpl *template.Template // parsed name template (nil = default naming)
 
-	mu       sync.Mutex
-	counters map[string]int // for append dedup mode
-	inflight map[string]int // base names currently being written, by capture count
+	mu        sync.Mutex
+	counters  map[string]int         // for append dedup mode
+	inflight  map[string]int         // base names currently being written, by capture count
+	baseLocks map[string]*sync.Mutex // serialises writes that resolve to the same base name
 
 	captures sync.WaitGroup
 
@@ -153,6 +154,14 @@ func New(cfg Config) (*Proxy, error) {
 		transport.TLSClientConfig.ServerName = cfg.TLSServerName
 	}
 
+	// Validate the filter here rather than on every request. shouldCapture
+	// treats an uncompilable pattern as "no match", so a typo would otherwise
+	// capture nothing at all while logging one error per request and reporting
+	// "captured=false", which is indistinguishable from a deliberate miss.
+	if cfg.Filter != "" && !doublestar.ValidatePattern(cfg.Filter) {
+		return nil, fmt.Errorf("invalid --filter glob %q", cfg.Filter)
+	}
+
 	var nameTmpl *template.Template
 	if cfg.NameTemplate != "" {
 		var err error
@@ -175,6 +184,7 @@ func New(cfg Config) (*Proxy, error) {
 		},
 		counters:   make(map[string]int),
 		inflight:   make(map[string]int),
+		baseLocks:  make(map[string]*sync.Mutex),
 		captureSem: make(chan struct{}, 20),
 	}
 
@@ -243,6 +253,12 @@ func (p *Proxy) WaitCaptures() {
 // waiting: there is no safe way to wait for captures that something may still
 // be adding to.
 func (p *Proxy) Shutdown(timeout time.Duration) error {
+	// Start failed, or was never called: there is nothing to drain, and
+	// dereferencing httpServer would panic in a deferred Shutdown.
+	if p.httpServer == nil {
+		return nil
+	}
+
 	// Split timeout: half for HTTP drain, half for capture drain.
 	httpDrain := timeout / 2
 	captureDrain := timeout - httpDrain
@@ -357,11 +373,20 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	// client has its response it may immediately call WaitCaptures or Shutdown,
 	// and a capture that has not yet joined the WaitGroup is invisible to both.
 	if shouldCapture {
+		// Drop the headers the client scoped to this hop before the capture ever
+		// sees them. They were withheld from the upstream, so recording them
+		// would make a coat demand, at replay, a header that had no part in
+		// producing the response being recorded.
+		capHeader := r.Header.Clone()
+		for name := range reqConnectionScoped {
+			capHeader.Del(name)
+		}
+
 		capReq := captureRequest{
 			Method:   r.Method,
 			URI:      r.URL.Path,
 			RawQuery: r.URL.RawQuery,
-			Header:   r.Header.Clone(),
+			Header:   capHeader,
 			Body:     reqBody,
 		}
 		p.captures.Go(func() {
@@ -442,9 +467,18 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 			reqHeaders[k] = req.Header.Get(k)
 		}
 
+		// The relay withholds hop-by-hop and Connection-scoped headers from the
+		// client, so the capture must withhold them too: a coat recording them
+		// asserts a response that never went over the wire, and a captured
+		// Connection: close makes the mock drop keep-alive for every client
+		// replaying it.
+		respScoped := connectionScopedHeaders(resp.Header)
 		respHeaders = make(map[string]string)
 		for k := range resp.Header {
-			if p.isStrippedHeader(k) || isContentLengthHeader(k) || (decompressed && isContentEncodingHeader(k)) {
+			if p.isStrippedHeader(k) || isHopByHopHeader(k) || respScoped[strings.ToLower(k)] {
+				continue
+			}
+			if isContentLengthHeader(k) || (decompressed && isContentEncodingHeader(k)) {
 				continue
 			}
 			respHeaders[k] = resp.Header.Get(k)
@@ -505,14 +539,14 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 	}
 	defer p.releaseFilename(base)
 
-	// Write body to a separate file if threshold is exceeded.
+	// Decide the body file before marshalling, but do not put it on disk until
+	// the coat itself has been written: a body file left behind by a capture
+	// whose coat failed to write would be picked up by the next capture of the
+	// same request, pairing one interaction's coat with another's body.
+	var bodyFileName, bodyFileContent string
 	if p.config.BodyFileThreshold > 0 && len(responseBody) > p.config.BodyFileThreshold {
-		bodyFileName := strings.TrimSuffix(filename, ".yaml") + "_body.txt"
-		bodyFilePath := filepath.Join(p.config.WriteDir, bodyFileName)
-		if err := os.WriteFile(bodyFilePath, []byte(responseBody), 0600); err != nil {
-			p.logger.Error("failed to write body file", "path", bodyFilePath, "error", err)
-			return
-		}
+		bodyFileName = strings.TrimSuffix(filename, ".yaml") + "_body.txt"
+		bodyFileContent = responseBody
 		coatDef.Coats[0].Response.Body = ""
 		coatDef.Coats[0].Response.BodyFile = bodyFileName
 	}
@@ -523,12 +557,55 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 		return
 	}
 
+	// Serialise against any other capture writing this same name.
+	baseMu := p.lockBase(base)
+	baseMu.Lock()
+	defer baseMu.Unlock()
+
 	fullPath := filepath.Join(p.config.WriteDir, filename)
 	if err := os.WriteFile(fullPath, data, 0600); err != nil {
 		p.logger.Error("failed to write coat file", "path", fullPath, "error", err)
-	} else if p.config.Verbose {
+		return
+	}
+
+	if bodyFileName != "" {
+		bodyFilePath := filepath.Join(p.config.WriteDir, bodyFileName)
+		if err := os.WriteFile(bodyFilePath, []byte(bodyFileContent), 0600); err != nil {
+			p.logger.Error("failed to write body file, removing the coat that references it",
+				"path", bodyFilePath, "coat", fullPath, "error", err)
+			if rmErr := os.Remove(fullPath); rmErr != nil {
+				p.logger.Error("failed to remove the orphaned coat file", "path", fullPath, "error", rmErr)
+			}
+			return
+		}
+	}
+
+	if p.config.Verbose {
 		p.logger.Info("captured coat file", "path", fullPath)
 	}
+}
+
+// lockBase returns the mutex serialising writes for a capture base name,
+// creating it on first use.
+//
+// Two captures can resolve to the same filename -- the default dedupe mode
+// gives every capture of a request the same stable name, and the base
+// deliberately excludes the query string, so requests differing only by query
+// collide. os.WriteFile is open(O_TRUNC) then write with nothing pairing the
+// two, so concurrent writers can interleave as A-open, B-open (truncating),
+// A-write, B-write and leave B's bytes over the head of A's: an unparseable
+// coat file on disk. Serialising by base means the last writer wins whole,
+// while captures of different requests still run concurrently up to captureSem.
+func (p *Proxy) lockBase(base string) *sync.Mutex {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	mu, ok := p.baseLocks[base]
+	if !ok {
+		mu = &sync.Mutex{}
+		p.baseLocks[base] = mu
+	}
+	return mu
 }
 
 // captureRequest holds request data copied from *http.Request before the
@@ -621,8 +698,18 @@ func (p *Proxy) generateFilenameLocked(method, urlPath string, status int) (stri
 	switch p.config.Dedupe {
 	case "skip":
 		// Check if a file with this base already exists (any naming scheme).
-		matches, _ := filepath.Glob(filepath.Join(p.config.WriteDir, base+"*.yaml"))
-		if len(matches) > 0 {
+		// The pattern is matched against the directory listing rather than
+		// interpolated into a glob: --write-dir is user-supplied, and a path
+		// containing '[' either changes the pattern's meaning or fails to
+		// compile, both of which silently answer "nothing here" and turn skip
+		// into overwrite.
+		exists, err := p.captureExists(base)
+		if err != nil {
+			p.logger.Error("dedupe=skip could not check for an existing capture; skipping this capture rather than risk a duplicate",
+				"write_dir", p.config.WriteDir, "base", base, "error", err)
+			return "", ""
+		}
+		if exists {
 			return "", "" // Signal to skip.
 		}
 		// A capture already writing this base has not appeared on disk yet, but
@@ -631,7 +718,12 @@ func (p *Proxy) generateFilenameLocked(method, urlPath string, status int) (stri
 		if p.inflight[base] > 0 {
 			return "", ""
 		}
-		return fmt.Sprintf("%s_%d.yaml", base, ts), base
+		// No timestamp: skip guarantees one file per request, so a timestamp
+		// only made the name unpredictable. It also meant two concurrent
+		// captures that got past the check together landed on different paths
+		// whenever they straddled a second boundary, writing the two files skip
+		// exists to prevent.
+		return fmt.Sprintf("%s.yaml", base), base
 
 	case "append":
 		counter := p.counters[base]
@@ -644,6 +736,32 @@ func (p *Proxy) generateFilenameLocked(method, urlPath string, status int) (stri
 	default: // overwrite
 		return fmt.Sprintf("%s.yaml", base), base
 	}
+}
+
+// captureExists reports whether a capture for this base name is already on
+// disk, under any of the naming schemes.
+//
+// It lists the directory and compares prefixes rather than building a glob out
+// of p.config.WriteDir. A --write-dir containing a glob metacharacter would
+// otherwise either silently change the pattern's meaning ("/tmp/run[1]" makes
+// "[1]" a character class) or fail to compile, and both look identical to "no
+// existing capture" -- turning dedupe=skip into overwrite with nothing logged.
+func (p *Proxy) captureExists(base string) (bool, error) {
+	entries, err := os.ReadDir(p.config.WriteDir)
+	if err != nil {
+		return false, fmt.Errorf("reading %s: %w", p.config.WriteDir, err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		name := entry.Name()
+		if strings.HasPrefix(name, base) && strings.HasSuffix(name, ".yaml") {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (p *Proxy) captureBodyEnabled() bool {
@@ -695,9 +813,9 @@ func connectionScopedHeaders(h http.Header) map[string]bool {
 // Every header a coat records becomes a match constraint the replayed request
 // must satisfy. Recording these ties the coat to the tool that captured it: a
 // coat taken with curl carries User-Agent: curl/8.7.1 and Accept: */*, and any
-// other client replaying the identical request gets a 404. Content-Length and
-// Host describe the message and its destination, not its identity, and
-// Accept-Encoding is added by the transport rather than the caller.
+// other client replaying the identical request gets a 404. Content-Length
+// describes the message rather than its identity, and Accept-Encoding is added
+// by the transport rather than the caller.
 //
 // Headers that genuinely qualify a request -- Content-Type, and custom headers
 // such as X-Api-Key -- are still captured.
@@ -706,13 +824,20 @@ var clientSpecificRequestHeaders = map[string]struct{}{
 	"accept-encoding": {},
 	"accept-language": {},
 	"content-length":  {},
-	"host":            {},
 	"user-agent":      {},
 }
 
 // isUncapturedRequestHeader reports whether a request header should be left out
-// of a captured coat, covering both connection-scoped headers and the
+// of a captured coat, covering the static hop-by-hop set and the
 // client-specific set above.
+//
+// Headers the client scoped to this hop by naming them in its Connection header
+// are handled separately, in handleRequest: they vary per message, so they are
+// removed from the cloned header before the capture is built rather than
+// decided here.
+//
+// Host is not listed: net/http moves it to Request.Host and deletes it from
+// Request.Header, so it never reaches a capture in the first place.
 func isUncapturedRequestHeader(h string) bool {
 	if isHopByHopHeader(h) {
 		return true

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -34,6 +34,10 @@ var sanitiseRe = regexp.MustCompile(`[^a-zA-Z0-9_-]`)
 // maxBodySize is the maximum number of bytes read from request or response bodies.
 const maxBodySize = 10 << 20 // 10 MiB
 
+// CaptureConcurrency is how many captures may be writing at once. Exported so
+// tests assert against the real bound rather than a copy of the number.
+const CaptureConcurrency = 20
+
 // hopByHopHeaders are headers that must not be forwarded by proxies.
 var hopByHopHeaders = map[string]struct{}{
 	"Connection":          {},
@@ -185,7 +189,7 @@ func New(cfg Config) (*Proxy, error) {
 		counters:   make(map[string]int),
 		inflight:   make(map[string]int),
 		baseLocks:  make(map[string]*sync.Mutex),
-		captureSem: make(chan struct{}, 20),
+		captureSem: make(chan struct{}, CaptureConcurrency),
 	}
 
 	return p, nil
@@ -244,8 +248,9 @@ func (p *Proxy) WaitCaptures() {
 //
 // The HTTP drain must come first, and must have succeeded. While handlers can
 // still run they keep registering captures, so waiting on the capture group
-// alongside them both races the registration (Add concurrent with Wait is
-// documented WaitGroup misuse, and panics) and misses every capture those
+// alongside them both races the registration (Add is documented WaitGroup
+// misuse when it takes the counter from zero to positive while a Wait is in
+// progress, and panics when it does) and misses every capture those
 // requests go on to spawn -- silently losing exactly the coat files the user
 // was recording when they pressed Ctrl-C.
 //
@@ -269,8 +274,9 @@ func (p *Proxy) Shutdown(timeout time.Duration) error {
 		// The drain gave up with connections still active, and it does not stop
 		// the handlers running on them. Those handlers can still reach
 		// captures.Go, so waiting here would be the very race this ordering was
-		// meant to avoid: Add concurrent with Wait is documented WaitGroup
-		// misuse and panics. Captures still in flight are lost, which is the
+		// meant to avoid -- Add taking the counter from zero to positive while a
+		// Wait is in progress is documented WaitGroup misuse, and panics when the
+		// interleaving lands. Captures still in flight are lost, which is the
 		// nature of a shutdown that has already run out of time.
 		return err
 	}
@@ -632,8 +638,8 @@ type nameTemplateData struct {
 //
 // Only the decision is serialised, not the write. Holding p.mu across the write
 // would make every capture wait for whichever one is currently touching the
-// disk -- so a single slow write stalls all of them, and captureSem's bound of
-// 20 concurrent captures becomes unreachable.
+// disk -- so a single slow write stalls all of them, and the CaptureConcurrency
+// bound becomes unreachable.
 func (p *Proxy) reserveFilename(method, urlPath string, status int) (filename, base string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/bmatcuk/doublestar/v4"
+	"github.com/yesdevnull/trenchcoat/internal/coat"
 	"gopkg.in/yaml.v3"
 )
 
@@ -511,7 +512,7 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 				Name: fmt.Sprintf("%s %s", req.Method, req.URI),
 				Request: coatRequest{
 					Method: req.Method,
-					URI:    req.URI,
+					URI:    escapeCapturedURI(req.URI),
 				},
 				Response: coatResponse{
 					Code:    resp.StatusCode,
@@ -938,6 +939,37 @@ func isContentLengthHeader(h string) bool {
 // readability -- the recorded body is no longer in that encoding.
 func isContentEncodingHeader(h string) bool {
 	return strings.EqualFold(h, "content-encoding")
+}
+
+// globEscaper escapes the characters doublestar gives special meaning to, so a
+// pattern built from them matches them literally.
+var globEscaper = strings.NewReplacer(
+	`\`, `\\`,
+	`*`, `\*`,
+	`?`, `\?`,
+	`[`, `\[`,
+	`]`, `\]`,
+	`{`, `\{`,
+	`}`, `\}`,
+)
+
+// escapeCapturedURI turns the path a capture was taken from into a request.uri
+// that means that path and no other.
+//
+// A URI is read as a glob as soon as it holds one of coat.GlobMetacharacters,
+// and a captured path may hold one: filter[name]-style APIs are ordinary. Left
+// verbatim, a balanced bracket quietly changes the coat's meaning --
+// /api/items[abc] is a character class matching /api/itemsa, /api/itemsb and
+// /api/itemsc but never the path recorded -- and an unbalanced one does not
+// compile at all, so the proxy emits a coat `trenchcoat validate` rejects.
+//
+// Paths with no metacharacter are left exactly as captured: they are matched
+// literally, so an escape would be part of the path the coat demands.
+func escapeCapturedURI(urlPath string) string {
+	if !strings.ContainsAny(urlPath, coat.GlobMetacharacters) {
+		return urlPath
+	}
+	return globEscaper.Replace(urlPath)
 }
 
 // SanitisePath converts a URL path to a filename-safe string.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -549,10 +549,20 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 	}
 	defer p.releaseFilename(base)
 
-	// Decide the body file before marshalling, but do not put it on disk until
-	// the coat itself has been written: a body file left behind by a capture
-	// whose coat failed to write would be picked up by the next capture of the
-	// same request, pairing one interaction's coat with another's body.
+	// Decide the body file before marshalling. Both files are staged as temps
+	// and the body is renamed into place first, so the coat's rename is the one
+	// point at which the capture becomes visible and a coat never names a
+	// body_file that is not on disk yet. A coat published ahead of its body is
+	// worse than either file being missing: the server answers that route with
+	// 500, `serve --watch` on the capture directory reloads on the coat's rename
+	// and starts doing so, and a process killed in that window leaves the broken
+	// coat behind for good -- under dedupe=skip permanently, since captureExists
+	// then skips every future capture of the request that would repair it.
+	//
+	// A body file left behind by a coat whose rename failed is harmless:
+	// bodyFileName is derived from filename, so the next capture of the same
+	// request overwrites it under overwrite and skip, and under append both
+	// names carry the same counter.
 	var bodyFileName, bodyFileContent string
 	if p.config.BodyFileThreshold > 0 && len(responseBody) > p.config.BodyFileThreshold {
 		bodyFileName = strings.TrimSuffix(filename, ".yaml") + "_body.txt"
@@ -573,21 +583,29 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 	defer baseMu.Unlock()
 
 	fullPath := filepath.Join(p.config.WriteDir, filename)
-	if err := writeFileAtomic(fullPath, data); err != nil {
+	coatTmp, err := stageFile(fullPath, data)
+	if err != nil {
 		p.logger.Error("failed to write coat file", "path", fullPath, "error", err)
 		return
 	}
 
 	if bodyFileName != "" {
 		bodyFilePath := filepath.Join(p.config.WriteDir, bodyFileName)
-		if err := writeFileAtomic(bodyFilePath, []byte(bodyFileContent)); err != nil {
-			p.logger.Error("failed to write body file, removing the coat that references it",
+		bodyTmp, err := stageFile(bodyFilePath, []byte(bodyFileContent))
+		if err == nil {
+			err = commitStaged(bodyTmp, bodyFilePath)
+		}
+		if err != nil {
+			p.logger.Error("failed to write body file, discarding the coat that references it",
 				"path", bodyFilePath, "coat", fullPath, "error", err)
-			if rmErr := os.Remove(fullPath); rmErr != nil {
-				p.logger.Error("failed to remove the orphaned coat file", "path", fullPath, "error", rmErr)
-			}
+			_ = os.Remove(coatTmp)
 			return
 		}
+	}
+
+	if err := commitStaged(coatTmp, fullPath); err != nil {
+		p.logger.Error("failed to write coat file", "path", fullPath, "error", err)
+		return
 	}
 
 	if p.config.Verbose {
@@ -607,20 +625,28 @@ func tempPathFor(path string) string {
 	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".tmp")
 }
 
-// writeFileAtomic writes data to path so that no reader ever observes a partial
-// file: it writes a temp file in the same directory and renames it into place,
-// and rename is atomic.
+// stageFile writes data to the temp path beside path, returning that temp path
+// for commitStaged to rename into place. Staging and committing are separate so
+// a capture writing two files can put both on disk before either is visible.
 //
-// os.WriteFile truncates and then writes, so anything reading concurrently --
-// `trenchcoat serve --watch` pointed at the capture directory, or `trenchcoat
-// validate` -- sees a prefix of the new content or an empty file, neither of
-// which is a valid coat. The temp file must share a directory with the
-// destination, since rename cannot cross filesystems.
-func writeFileAtomic(path string, data []byte) error {
+// The temp file must share a directory with the destination, since rename
+// cannot cross filesystems.
+func stageFile(path string, data []byte) (string, error) {
 	tmp := tempPathFor(path)
 	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return fmt.Errorf("writing %s: %w", tmp, err)
+		return "", fmt.Errorf("writing %s: %w", tmp, err)
 	}
+	return tmp, nil
+}
+
+// commitStaged renames a staged file into place so that no reader ever observes
+// a partial file, removing the temp file if the rename fails.
+//
+// Writing in place with os.WriteFile would truncate and then write, so anything
+// reading concurrently -- `trenchcoat serve --watch` pointed at the capture
+// directory, or `trenchcoat validate` -- would see a prefix of the new content
+// or an empty file, neither of which is a valid coat. Rename is atomic.
+func commitStaged(tmp, path string) error {
 	if err := os.Rename(tmp, path); err != nil {
 		_ = os.Remove(tmp)
 		return fmt.Errorf("renaming %s to %s: %w", tmp, path, err)

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -215,14 +215,25 @@ func (p *Proxy) WaitCaptures() {
 	p.captures.Wait()
 }
 
-// Shutdown gracefully stops the proxy, waiting for pending captures to complete
-// within half the timeout, then draining HTTP connections with the remaining time.
+// Shutdown gracefully stops the proxy, draining HTTP connections within half
+// the timeout, then waiting for pending captures with the remaining time.
+//
+// The HTTP drain must come first. While the server is still accepting,
+// handlers keep registering captures, so waiting on the capture group first
+// both races with the registration (Add concurrent with Wait is documented
+// WaitGroup misuse, and panics) and misses every capture the requests still in
+// flight go on to spawn -- silently losing exactly the coat files the user was
+// trying to record when they pressed Ctrl-C.
 func (p *Proxy) Shutdown(timeout time.Duration) error {
-	// Split timeout: half for capture drain, half for HTTP drain.
-	captureDrain := timeout / 2
-	httpDrain := timeout - captureDrain
+	// Split timeout: half for HTTP drain, half for capture drain.
+	httpDrain := timeout / 2
+	captureDrain := timeout - httpDrain
 
-	// Wait for captures with timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), httpDrain)
+	defer cancel()
+	shutdownErr := p.httpServer.Shutdown(ctx)
+
+	// No handler can start now, so the capture group can only shrink.
 	done := make(chan struct{})
 	go func() {
 		p.captures.Wait()
@@ -235,9 +246,7 @@ func (p *Proxy) Shutdown(timeout time.Duration) error {
 		p.logger.Warn("timed out waiting for pending captures to complete")
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), httpDrain)
-	defer cancel()
-	return p.httpServer.Shutdown(ctx)
+	return shutdownErr
 }
 
 func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
@@ -307,6 +316,24 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Register the capture before the response reaches the client. Once the
+	// client has its response it may immediately call WaitCaptures or Shutdown,
+	// and a capture that has not yet joined the WaitGroup is invisible to both.
+	if shouldCapture {
+		capReq := captureRequest{
+			Method:   r.Method,
+			URI:      r.URL.Path,
+			RawQuery: r.URL.RawQuery,
+			Header:   r.Header.Clone(),
+			Body:     reqBody,
+		}
+		p.captures.Go(func() {
+			p.captureSem <- struct{}{}
+			defer func() { <-p.captureSem }()
+			p.captureCoatFromCopy(capReq, upstreamResp, respBody)
+		})
+	}
+
 	// Relay response to client, filtering hop-by-hop headers.
 	for k, vv := range upstreamResp.Header {
 		if isHopByHopHeader(k) {
@@ -331,21 +358,6 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 		)
 	}
 
-	// Capture if applicable.
-	if shouldCapture {
-		capReq := captureRequest{
-			Method:   r.Method,
-			URI:      r.URL.Path,
-			RawQuery: r.URL.RawQuery,
-			Header:   r.Header.Clone(),
-			Body:     reqBody,
-		}
-		p.captures.Go(func() {
-			p.captureSem <- struct{}{}
-			defer func() { <-p.captureSem }()
-			p.captureCoatFromCopy(capReq, upstreamResp, respBody)
-		})
-	}
 }
 
 func (p *Proxy) shouldCapture(urlPath string) bool {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -717,12 +717,21 @@ func (p *Proxy) reserveFilename(method, urlPath string, status int) (filename, b
 }
 
 // releaseFilename records that a capture has finished writing base.
+//
+// The last capture for a base drops its lock as well as its inflight entry.
+// inflight[base] is non-zero for the whole time any capture holds or is waiting
+// on that lock -- it is taken before the lock and released after it, since the
+// deferred Unlock runs first -- so a base with no captures left in flight has no
+// one holding its mutex, and the next capture of the same request simply creates
+// a fresh one. Without this the proxy accumulates a mutex per distinct
+// METHOD_path_status for the life of the process, in every dedupe mode.
 func (p *Proxy) releaseFilename(base string) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
 	if p.inflight[base] <= 1 {
 		delete(p.inflight, base)
+		delete(p.baseLocks, base)
 		return
 	}
 	p.inflight[base]--

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -76,6 +76,7 @@ type Proxy struct {
 
 	mu       sync.Mutex
 	counters map[string]int // for append dedup mode
+	inflight map[string]int // base names currently being written, by capture count
 
 	captures   sync.WaitGroup
 	captureSem chan struct{} // bounds concurrent capture goroutines
@@ -161,6 +162,7 @@ func New(cfg Config) (*Proxy, error) {
 			},
 		},
 		counters:   make(map[string]int),
+		inflight:   make(map[string]int),
 		captureSem: make(chan struct{}, 20),
 	}
 
@@ -460,20 +462,19 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 		coatDef.Coats[0].Request.Query = req.RawQuery
 	}
 
-	// Choosing the filename and writing it must be one atomic step. Selection
-	// asks whether a file already exists (dedupe=skip) and hands out a name
-	// stamped with the current second; if another capture can slip between the
-	// question and the write, two concurrent captures of the same request both
-	// see nothing on disk and, if they straddle a second boundary, write two
-	// files where skip promises one.
-	p.mu.Lock()
-	defer p.mu.Unlock()
-
-	filename := p.generateFilenameLocked(req.Method, req.URI, resp.StatusCode)
+	// Reserve the filename, which both picks it and records that this capture is
+	// about to write it. dedupe=skip asks whether a file already exists, and the
+	// answer is only meaningful if concurrent captures of the same request can
+	// see each other's intent -- otherwise they all look at an empty directory
+	// and, if they straddle a second boundary (the name carries a
+	// one-second-resolution timestamp), write several files where skip promises
+	// one.
+	filename, base := p.reserveFilename(req.Method, req.URI, resp.StatusCode)
 	if filename == "" {
-		// Skip dedup — file already exists.
+		// Skip dedup — file already exists or is being written.
 		return
 	}
+	defer p.releaseFilename(base)
 
 	// Write body to a separate file if threshold is exceeded.
 	if p.config.BodyFileThreshold > 0 && len(responseBody) > p.config.BodyFileThreshold {
@@ -518,11 +519,45 @@ type nameTemplateData struct {
 	Status int
 }
 
-// generateFilenameLocked picks the filename for a capture. The caller must hold
-// p.mu and must still hold it when it writes the file: for dedupe=skip the
-// returned name is only correct as long as nothing else writes in between.
-// It returns "" when dedupe=skip and a capture for this request already exists.
-func (p *Proxy) generateFilenameLocked(method, urlPath string, status int) string {
+// reserveFilename picks the filename for a capture and records that this
+// capture is writing it, returning the filename and the base name to release
+// once the write has finished. It returns "" when dedupe=skip and a capture for
+// this request already exists on disk or is in flight.
+//
+// Only the decision is serialised, not the write. Holding p.mu across the write
+// would make every capture wait for whichever one is currently touching the
+// disk -- so a single slow write stalls all of them, and captureSem's bound of
+// 20 concurrent captures becomes unreachable.
+func (p *Proxy) reserveFilename(method, urlPath string, status int) (filename, base string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	filename, base = p.generateFilenameLocked(method, urlPath, status)
+	if filename == "" {
+		return "", ""
+	}
+
+	p.inflight[base]++
+	return filename, base
+}
+
+// releaseFilename records that a capture has finished writing base.
+func (p *Proxy) releaseFilename(base string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.inflight[base] <= 1 {
+		delete(p.inflight, base)
+		return
+	}
+	p.inflight[base]--
+}
+
+// generateFilenameLocked picks the filename for a capture, returning it
+// alongside the base name it was derived from. The caller must hold p.mu.
+// It returns "" when dedupe=skip and a capture for this request already exists
+// on disk or is in flight.
+func (p *Proxy) generateFilenameLocked(method, urlPath string, status int) (string, string) {
 	ts := time.Now().Unix()
 	sanitised := SanitisePath(urlPath)
 
@@ -559,20 +594,26 @@ func (p *Proxy) generateFilenameLocked(method, urlPath string, status int) strin
 		// Check if a file with this base already exists (any naming scheme).
 		matches, _ := filepath.Glob(filepath.Join(p.config.WriteDir, base+"*.yaml"))
 		if len(matches) > 0 {
-			return "" // Signal to skip.
+			return "", "" // Signal to skip.
 		}
-		return fmt.Sprintf("%s_%d.yaml", base, ts)
+		// A capture already writing this base has not appeared on disk yet, but
+		// it is just as much a reason to skip: without this, concurrent captures
+		// of one request all see an empty directory and each write a file.
+		if p.inflight[base] > 0 {
+			return "", ""
+		}
+		return fmt.Sprintf("%s_%d.yaml", base, ts), base
 
 	case "append":
 		counter := p.counters[base]
 		p.counters[base] = counter + 1
 		if counter == 0 {
-			return fmt.Sprintf("%s_%d.yaml", base, ts)
+			return fmt.Sprintf("%s_%d.yaml", base, ts), base
 		}
-		return fmt.Sprintf("%s_%d_%d.yaml", base, counter, ts)
+		return fmt.Sprintf("%s_%d_%d.yaml", base, counter, ts), base
 
 	default: // overwrite
-		return fmt.Sprintf("%s.yaml", base)
+		return fmt.Sprintf("%s.yaml", base), base
 	}
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -274,8 +274,16 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Forward request to upstream.
+	//
+	// Join the escaped forms as well as the decoded ones. URL.String() prefers
+	// RawPath when it is a valid encoding of Path, so without this an encoded
+	// separator in the client's path is handed upstream as a real one --
+	// /seg%2Fment arrives as /seg/ment and hits a different route than the
+	// client asked for. A capture tool that rewrites the request in transit is
+	// recording something that never happened.
 	upstreamURL := *p.upstream
 	upstreamURL.Path = singleJoiningSlash(upstreamURL.Path, r.URL.Path)
+	upstreamURL.RawPath = singleJoiningSlash(p.upstream.EscapedPath(), r.URL.EscapedPath())
 	upstreamURL.RawQuery = r.URL.RawQuery
 
 	proxyReq, err := http.NewRequestWithContext(r.Context(), r.Method, upstreamURL.String(), bytes.NewReader(reqBody))

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -392,9 +392,10 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 
 		respHeaders = make(map[string]string)
 		for k := range resp.Header {
-			if !p.isStrippedHeader(k) && (!decompressed || !isEncodingHeader(k)) {
-				respHeaders[k] = resp.Header.Get(k)
+			if p.isStrippedHeader(k) || isContentLengthHeader(k) || (decompressed && isContentEncodingHeader(k)) {
+				continue
 			}
+			respHeaders[k] = resp.Header.Get(k)
 		}
 	}
 
@@ -565,11 +566,20 @@ func isHopByHopHeader(h string) bool {
 	return ok
 }
 
-// isEncodingHeader returns true for headers that should be stripped from
-// captured coat files when the body has been decompressed for readability.
-func isEncodingHeader(h string) bool {
-	lower := strings.ToLower(h)
-	return lower == "content-encoding" || lower == "content-length"
+// isContentLengthHeader returns true for the Content-Length header, which is
+// never recorded in a captured coat. The captured body is what the mock server
+// replays, and it differs from the upstream body whenever it is pretty-printed
+// or decompressed; net/http derives the correct length when serving, so a
+// recorded length can only ever be wrong.
+func isContentLengthHeader(h string) bool {
+	return strings.EqualFold(h, "content-length")
+}
+
+// isContentEncodingHeader returns true for the Content-Encoding header, which
+// is stripped from captured coat files when the body has been decompressed for
+// readability -- the recorded body is no longer in that encoding.
+func isContentEncodingHeader(h string) bool {
+	return strings.EqualFold(h, "content-encoding")
 }
 
 // SanitisePath converts a URL path to a filename-safe string.

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -78,8 +78,20 @@ type Proxy struct {
 	counters map[string]int // for append dedup mode
 	inflight map[string]int // base names currently being written, by capture count
 
-	captures   sync.WaitGroup
-	captureSem chan struct{} // bounds concurrent capture goroutines
+	captures sync.WaitGroup
+
+	// captureSem bounds how many captures may be writing at once. It is
+	// acquired inside the capture goroutine, not before it is spawned, so it
+	// bounds concurrent disk work rather than the number of goroutines: a burst
+	// of requests queues that many goroutines, each holding its copy of the
+	// request and response bodies (up to maxBodySize each) until a slot frees.
+	//
+	// Acquiring it in the handler instead would bound the memory too, at the
+	// cost of blocking the proxied request on capture I/O -- a slow or stalled
+	// --write-dir would then stall the proxying itself, which is the one thing
+	// a transparent proxy must not do. Bounded memory is not worth coupling
+	// relay latency to the disk.
+	captureSem chan struct{}
 }
 
 // New creates a new Proxy.
@@ -295,9 +307,11 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Copy headers, filtering hop-by-hop headers.
+	// Copy headers, filtering hop-by-hop headers and any the client scoped to
+	// this hop by naming them in its Connection header.
+	reqConnectionScoped := connectionScopedHeaders(r.Header)
 	for k, vv := range r.Header {
-		if isHopByHopHeader(k) {
+		if isHopByHopHeader(k) || reqConnectionScoped[strings.ToLower(k)] {
 			continue
 		}
 		for _, v := range vv {
@@ -344,9 +358,11 @@ func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
-	// Relay response to client, filtering hop-by-hop headers.
+	// Relay response to client, filtering hop-by-hop headers and any the
+	// upstream scoped to its hop by naming them in its Connection header.
+	respConnectionScoped := connectionScopedHeaders(upstreamResp.Header)
 	for k, vv := range upstreamResp.Header {
-		if isHopByHopHeader(k) {
+		if isHopByHopHeader(k) || respConnectionScoped[strings.ToLower(k)] {
 			continue
 		}
 		for _, v := range vv {
@@ -635,6 +651,28 @@ func (p *Proxy) isStrippedHeader(header string) bool {
 func isHopByHopHeader(h string) bool {
 	_, ok := hopByHopHeaders[http.CanonicalHeaderKey(h)]
 	return ok
+}
+
+// connectionScopedHeaders returns the lower-cased names a message listed in its
+// Connection header, which RFC 9110 7.6.1 scopes to that hop alone and which a
+// proxy must not forward. The static hopByHopHeaders set covers the standard
+// names; this covers the ones a peer nominates per message, such as
+// "Connection: keep-alive, X-Trace-Token".
+func connectionScopedHeaders(h http.Header) map[string]bool {
+	var scoped map[string]bool
+	for _, value := range h.Values("Connection") {
+		for _, token := range strings.Split(value, ",") {
+			token = strings.ToLower(strings.TrimSpace(token))
+			if token == "" {
+				continue
+			}
+			if scoped == nil {
+				scoped = make(map[string]bool)
+			}
+			scoped[token] = true
+		}
+	}
+	return scoped
 }
 
 // clientSpecificRequestHeaders are request headers that describe the client or

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -405,9 +405,10 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 	if !p.config.NoHeaders {
 		reqHeaders = make(map[string]string)
 		for k := range req.Header {
-			if !p.isStrippedHeader(k) {
-				reqHeaders[k] = req.Header.Get(k)
+			if p.isStrippedHeader(k) || isUncapturedRequestHeader(k) {
+				continue
 			}
+			reqHeaders[k] = req.Header.Get(k)
 		}
 
 		respHeaders = make(map[string]string)
@@ -592,6 +593,39 @@ func (p *Proxy) isStrippedHeader(header string) bool {
 // should not be forwarded by proxies.
 func isHopByHopHeader(h string) bool {
 	_, ok := hopByHopHeaders[http.CanonicalHeaderKey(h)]
+	return ok
+}
+
+// clientSpecificRequestHeaders are request headers that describe the client or
+// the connection rather than the request, and so are never recorded in a
+// captured coat.
+//
+// Every header a coat records becomes a match constraint the replayed request
+// must satisfy. Recording these ties the coat to the tool that captured it: a
+// coat taken with curl carries User-Agent: curl/8.7.1 and Accept: */*, and any
+// other client replaying the identical request gets a 404. Content-Length and
+// Host describe the message and its destination, not its identity, and
+// Accept-Encoding is added by the transport rather than the caller.
+//
+// Headers that genuinely qualify a request -- Content-Type, and custom headers
+// such as X-Api-Key -- are still captured.
+var clientSpecificRequestHeaders = map[string]struct{}{
+	"accept":          {},
+	"accept-encoding": {},
+	"accept-language": {},
+	"content-length":  {},
+	"host":            {},
+	"user-agent":      {},
+}
+
+// isUncapturedRequestHeader reports whether a request header should be left out
+// of a captured coat, covering both connection-scoped headers and the
+// client-specific set above.
+func isUncapturedRequestHeader(h string) bool {
+	if isHopByHopHeader(h) {
+		return true
+	}
+	_, ok := clientSpecificRequestHeaders[strings.ToLower(h)]
 	return ok
 }
 

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -232,12 +232,16 @@ func (p *Proxy) WaitCaptures() {
 // Shutdown gracefully stops the proxy, draining HTTP connections within half
 // the timeout, then waiting for pending captures with the remaining time.
 //
-// The HTTP drain must come first. While the server is still accepting,
-// handlers keep registering captures, so waiting on the capture group first
-// both races with the registration (Add concurrent with Wait is documented
-// WaitGroup misuse, and panics) and misses every capture the requests still in
-// flight go on to spawn -- silently losing exactly the coat files the user was
-// trying to record when they pressed Ctrl-C.
+// The HTTP drain must come first, and must have succeeded. While handlers can
+// still run they keep registering captures, so waiting on the capture group
+// alongside them both races the registration (Add concurrent with Wait is
+// documented WaitGroup misuse, and panics) and misses every capture those
+// requests go on to spawn -- silently losing exactly the coat files the user
+// was recording when they pressed Ctrl-C.
+//
+// A drain that times out leaves handlers running, so it returns without
+// waiting: there is no safe way to wait for captures that something may still
+// be adding to.
 func (p *Proxy) Shutdown(timeout time.Duration) error {
 	// Split timeout: half for HTTP drain, half for capture drain.
 	httpDrain := timeout / 2
@@ -245,9 +249,18 @@ func (p *Proxy) Shutdown(timeout time.Duration) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), httpDrain)
 	defer cancel()
-	shutdownErr := p.httpServer.Shutdown(ctx)
+	if err := p.httpServer.Shutdown(ctx); err != nil {
+		// The drain gave up with connections still active, and it does not stop
+		// the handlers running on them. Those handlers can still reach
+		// captures.Go, so waiting here would be the very race this ordering was
+		// meant to avoid: Add concurrent with Wait is documented WaitGroup
+		// misuse and panics. Captures still in flight are lost, which is the
+		// nature of a shutdown that has already run out of time.
+		return err
+	}
 
-	// No handler can start now, so the capture group can only shrink.
+	// The drain succeeded, so every handler has returned and no new one can
+	// start: the capture group can only shrink from here.
 	done := make(chan struct{})
 	go func() {
 		p.captures.Wait()
@@ -260,7 +273,7 @@ func (p *Proxy) Shutdown(timeout time.Duration) error {
 		p.logger.Warn("timed out waiting for pending captures to complete")
 	}
 
-	return shutdownErr
+	return nil
 }
 
 func (p *Proxy) handleRequest(w http.ResponseWriter, r *http.Request) {

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -573,14 +573,14 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 	defer baseMu.Unlock()
 
 	fullPath := filepath.Join(p.config.WriteDir, filename)
-	if err := os.WriteFile(fullPath, data, 0600); err != nil {
+	if err := writeFileAtomic(fullPath, data); err != nil {
 		p.logger.Error("failed to write coat file", "path", fullPath, "error", err)
 		return
 	}
 
 	if bodyFileName != "" {
 		bodyFilePath := filepath.Join(p.config.WriteDir, bodyFileName)
-		if err := os.WriteFile(bodyFilePath, []byte(bodyFileContent), 0600); err != nil {
+		if err := writeFileAtomic(bodyFilePath, []byte(bodyFileContent)); err != nil {
 			p.logger.Error("failed to write body file, removing the coat that references it",
 				"path", bodyFilePath, "coat", fullPath, "error", err)
 			if rmErr := os.Remove(fullPath); rmErr != nil {
@@ -595,17 +595,50 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 	}
 }
 
+// tempPathFor returns the path a capture writes before renaming into place.
+//
+// The name is derived from the destination rather than randomised. Captures
+// that resolve to the same destination are serialised by lockBase, so two of
+// them never hold this path at once, and a predictable name is no more exposed
+// than the destination itself -- which the proxy already creates, without
+// O_EXCL, at a name derived from the request. Keeping it predictable also means
+// a test can block a capture by placing a FIFO where it is about to write.
+func tempPathFor(path string) string {
+	return filepath.Join(filepath.Dir(path), "."+filepath.Base(path)+".tmp")
+}
+
+// writeFileAtomic writes data to path so that no reader ever observes a partial
+// file: it writes a temp file in the same directory and renames it into place,
+// and rename is atomic.
+//
+// os.WriteFile truncates and then writes, so anything reading concurrently --
+// `trenchcoat serve --watch` pointed at the capture directory, or `trenchcoat
+// validate` -- sees a prefix of the new content or an empty file, neither of
+// which is a valid coat. The temp file must share a directory with the
+// destination, since rename cannot cross filesystems.
+func writeFileAtomic(path string, data []byte) error {
+	tmp := tempPathFor(path)
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return fmt.Errorf("writing %s: %w", tmp, err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("renaming %s to %s: %w", tmp, path, err)
+	}
+	return nil
+}
+
 // lockBase returns the mutex serialising writes for a capture base name,
 // creating it on first use.
 //
 // Two captures can resolve to the same filename -- the default dedupe mode
 // gives every capture of a request the same stable name, and the base
 // deliberately excludes the query string, so requests differing only by query
-// collide. os.WriteFile is open(O_TRUNC) then write with nothing pairing the
-// two, so concurrent writers can interleave as A-open, B-open (truncating),
-// A-write, B-write and leave B's bytes over the head of A's: an unparseable
-// coat file on disk. Serialising by base means the last writer wins whole,
-// while captures of different requests still run concurrently up to captureSem.
+// collide. Rename makes the swap into place atomic, but both captures would
+// otherwise build their content in the same temp file, tearing that and then
+// renaming the result into place. Serialising by base gives each one exclusive
+// use of the temp path, so the last writer wins whole, while captures of
+// different requests still run concurrently up to CaptureConcurrency.
 func (p *Proxy) lockBase(base string) *sync.Mutex {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -451,8 +451,16 @@ func (p *Proxy) captureCoatFromCopy(req captureRequest, resp *http.Response, res
 		coatDef.Coats[0].Request.Query = req.RawQuery
 	}
 
-	// Generate filename.
-	filename := p.generateFilename(req.Method, req.URI, resp.StatusCode)
+	// Choosing the filename and writing it must be one atomic step. Selection
+	// asks whether a file already exists (dedupe=skip) and hands out a name
+	// stamped with the current second; if another capture can slip between the
+	// question and the write, two concurrent captures of the same request both
+	// see nothing on disk and, if they straddle a second boundary, write two
+	// files where skip promises one.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	filename := p.generateFilenameLocked(req.Method, req.URI, resp.StatusCode)
 	if filename == "" {
 		// Skip dedup — file already exists.
 		return
@@ -501,7 +509,11 @@ type nameTemplateData struct {
 	Status int
 }
 
-func (p *Proxy) generateFilename(method, urlPath string, status int) string {
+// generateFilenameLocked picks the filename for a capture. The caller must hold
+// p.mu and must still hold it when it writes the file: for dedupe=skip the
+// returned name is only correct as long as nothing else writes in between.
+// It returns "" when dedupe=skip and a capture for this request already exists.
+func (p *Proxy) generateFilenameLocked(method, urlPath string, status int) string {
 	ts := time.Now().Unix()
 	sanitised := SanitisePath(urlPath)
 
@@ -532,9 +544,6 @@ func (p *Proxy) generateFilename(method, urlPath string, status int) string {
 	} else {
 		base = fmt.Sprintf("%s_%s_%d", method, sanitised, status)
 	}
-
-	p.mu.Lock()
-	defer p.mu.Unlock()
 
 	switch p.config.Dedupe {
 	case "skip":

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1790,6 +1790,77 @@ func TestProxy_CapturedCoatReplaysFromAnotherClient(t *testing.T) {
 	}
 }
 
+func TestProxy_CapturedBracketedPathValidatesAndReplays(t *testing.T) {
+	// request.uri is recorded from the path the capture was taken from, and a
+	// path carrying a glob metacharacter stops meaning that path the moment the
+	// matcher reads it. /api/items[abc] is a character class matching
+	// /api/itemsa, /api/itemsb and /api/itemsc -- everything except the request
+	// that produced the coat. An unbalanced bracket fails louder: /api/items[]
+	// does not compile, so `trenchcoat validate` rejects a coat this tool wrote.
+	// Bracketed segments are ordinary in filter[name]-style APIs.
+	for _, path := range []string{"/api/items[abc]", "/api/items[]"} {
+		t.Run(path, func(t *testing.T) {
+			const body = "captured"
+			upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(200)
+				_, _ = fmt.Fprint(w, body)
+			}))
+			defer upstream.Close()
+
+			writeDir := t.TempDir()
+			p, err := proxy.New(proxy.Config{
+				UpstreamURL:  upstream.URL,
+				WriteDir:     writeDir,
+				StripHeaders: []string{},
+				Dedupe:       "overwrite",
+				Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+			})
+			if err != nil {
+				t.Fatalf("failed to create proxy: %v", err)
+			}
+			if _, err := p.Start("127.0.0.1:0"); err != nil {
+				t.Fatalf("failed to start proxy: %v", err)
+			}
+			t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+			resp, err := httpClient.Get(p.URL() + path)
+			if err != nil {
+				t.Fatalf("capture request failed: %v", err)
+			}
+			_ = resp.Body.Close()
+			p.WaitCaptures()
+
+			// LoadPaths validates, so this is `trenchcoat validate` on the capture.
+			loaded, errs := coat.LoadPaths([]string{writeDir})
+			if len(errs) > 0 {
+				t.Fatalf("the captured coat does not validate: %v", errs)
+			}
+			if len(loaded) != 1 {
+				t.Fatalf("expected 1 captured coat, got %d", len(loaded))
+			}
+
+			mock := server.New(loaded, server.Config{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+			addr, err := mock.Start("127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("failed to start mock: %v", err)
+			}
+			t.Cleanup(func() { _ = mock.Shutdown(5 * time.Second) })
+
+			replayed, err := httpClient.Get("http://" + addr + path)
+			if err != nil {
+				t.Fatalf("replay request failed: %v", err)
+			}
+			defer func() { _ = replayed.Body.Close() }()
+
+			got, _ := io.ReadAll(replayed.Body)
+			if replayed.StatusCode != http.StatusOK || string(got) != body {
+				t.Fatalf("replaying %s against its own capture got %d %q, want 200 %q",
+					path, replayed.StatusCode, got, body)
+			}
+		})
+	}
+}
+
 func TestProxy_DropsHeadersNamedInConnection(t *testing.T) {
 	// RFC 9110 7.6.1: the Connection header lists headers that are scoped to
 	// this hop only. Filtering just the static hop-by-hop set forwards them

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1909,3 +1909,169 @@ func TestProxy_CaptureOmitsConnectionScopedHeaders(t *testing.T) {
 		t.Errorf("Content-Type must still be captured, got %q", got)
 	}
 }
+
+func TestProxy_DedupeSkip_WriteDirContainingGlobMetacharacters(t *testing.T) {
+	// The existence check used to interpolate --write-dir into a glob pattern.
+	// A directory named "run[1]" made "[1]" a character class, so the check
+	// searched "run1", found nothing, and skip silently behaved as overwrite --
+	// writing a file per request instead of the one it promises.
+	// The response differs per request, so the file's contents say whether the
+	// later captures were skipped or wrote over the first. Counting files cannot
+	// tell: skip filenames are stable, so a skip that degrades to overwrite
+	// still leaves exactly one file behind.
+	var mu sync.Mutex
+	n := 0
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		n++
+		body := fmt.Sprintf("response-%d", n)
+		mu.Unlock()
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	writeDir := filepath.Join(t.TempDir(), "run[1]")
+	if err := os.MkdirAll(writeDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "skip",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	for range 3 {
+		resp, err := httpClient.Get(p.URL() + "/api/items")
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+		p.WaitCaptures()
+	}
+
+	content, err := os.ReadFile(filepath.Join(writeDir, "GET_api_items_200.yaml"))
+	if err != nil {
+		t.Fatalf("expected a captured coat: %v", err)
+	}
+	if !strings.Contains(string(content), "response-1") {
+		t.Fatalf("dedupe=skip kept the last capture rather than the first, so the existence check never saw the file it had already written:\n%s", content)
+	}
+}
+
+func TestProxy_DedupeSkip_FilenameIsStable(t *testing.T) {
+	// skip guarantees one file per request, so the name carries no timestamp:
+	// a predictable name is what makes a captured fixture referenceable from a
+	// test or a script.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "skip",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get(p.URL() + "/api/items")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	want := filepath.Join(writeDir, "GET_api_items_200.yaml")
+	if _, err := os.Stat(want); err != nil {
+		entries, _ := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
+		t.Fatalf("expected the stable name %s, found %v", filepath.Base(want), entries)
+	}
+}
+
+func TestProxy_BodyFileFailureRemovesTheCoatReferencingIt(t *testing.T) {
+	// A coat naming a body file that is not there is worse than no coat: it
+	// serves a 500 at replay for a capture the user believes succeeded. If the
+	// body cannot be written, the coat pointing at it must not survive either.
+	//
+	// The body file is made unwritable by pre-creating it as a directory, which
+	// os.WriteFile cannot overwrite.
+	body := strings.Repeat("x", 8192)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(writeDir, "GET_api_items_200_body.txt"), 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:       upstream.URL,
+		WriteDir:          writeDir,
+		StripHeaders:      []string{},
+		Dedupe:            "overwrite",
+		BodyFileThreshold: 1024,
+		Logger:            slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get(p.URL() + "/api/items")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	coatPath := filepath.Join(writeDir, "GET_api_items_200.yaml")
+	if _, err := os.Stat(coatPath); err == nil {
+		content, _ := os.ReadFile(coatPath)
+		t.Fatalf("the coat survived a failed body-file write, so replaying it would 500:\n%s", content)
+	}
+}
+
+func TestProxy_ShutdownBeforeStartIsNotAnError(t *testing.T) {
+	// Start assigns httpServer, so a deferred Shutdown after a failed or absent
+	// Start would otherwise dereference nil -- turning a reportable error into a
+	// panic in the caller's cleanup.
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL: "http://127.0.0.1:1",
+		WriteDir:    t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if err := p.Shutdown(time.Second); err != nil {
+		t.Fatalf("Shutdown before Start should be a no-op, got %v", err)
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1041,6 +1041,136 @@ func TestProxy_PrettyJSON(t *testing.T) {
 	}
 }
 
+func TestProxy_ShutdownWritesInFlightCaptures(t *testing.T) {
+	// Captures are the entire point of proxy mode, so Ctrl-C must not drop the
+	// requests that were in flight when it arrived. Enough concurrent requests
+	// to queue behind the capture semaphore, all released at once, so captures
+	// are still pending when the HTTP drain finishes.
+	const requests = 30
+
+	release := make(chan struct{})
+	var arrived sync.WaitGroup
+	arrived.Add(requests)
+
+	// A large body so marshalling and writing each coat takes long enough that
+	// a Shutdown which does not wait for captures demonstrably returns first.
+	payload := `{"data": "` + strings.Repeat("x", 2*1024*1024) + `"}`
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		arrived.Done()
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+
+	var clients sync.WaitGroup
+	for i := 0; i < requests; i++ {
+		clients.Add(1)
+		go func(n int) {
+			defer clients.Done()
+			resp, err := httpClient.Get(fmt.Sprintf("%s/item/%d", p.URL(), n))
+			if err != nil {
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}(i)
+	}
+
+	// All requests are parked in the upstream handler, so no capture has been
+	// registered yet. Shutdown starts from that state -- the situation on
+	// Ctrl-C mid-request -- and only then are the handlers released.
+	arrived.Wait()
+
+	shutdownErr := make(chan error, 1)
+	go func() { shutdownErr <- p.Shutdown(30 * time.Second) }()
+	// Only long enough for Shutdown to reach its drain; http.Server.Shutdown
+	// polls for idle connections on a backing-off interval, so a longer pause
+	// here would let it sleep through the window this test is aiming at.
+	time.Sleep(10 * time.Millisecond)
+	close(release)
+
+	if err := <-shutdownErr; err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+	clients.Wait()
+
+	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
+	if err != nil {
+		t.Fatalf("failed to glob: %v", err)
+	}
+	if len(files) != requests {
+		t.Fatalf("shutdown returned with %d of %d captures written; the rest were lost", len(files), requests)
+	}
+}
+
+func TestProxy_WaitCapturesAfterLargeResponse(t *testing.T) {
+	// WaitCaptures must account for a request whose response the client has
+	// already read. With registration happening after the response write, a
+	// body large enough to clear the write buffers lets the client return
+	// first, so WaitCaptures sees nothing pending and returns too early.
+	body := strings.Repeat("a", 64*1024)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get(p.URL() + "/large")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
+		t.Fatalf("reading body failed: %v", err)
+	}
+	_ = resp.Body.Close()
+
+	p.WaitCaptures()
+
+	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
+	if err != nil {
+		t.Fatalf("failed to glob: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("WaitCaptures returned before the capture was written, got %d files", len(files))
+	}
+}
+
 func TestProxy_PrettyJSON_DropsContentLength(t *testing.T) {
 	// Pretty-printing changes the body length, so the upstream's Content-Length
 	// no longer describes the captured body and must not be recorded.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1121,56 +1121,6 @@ func TestProxy_ShutdownWritesInFlightCaptures(t *testing.T) {
 	}
 }
 
-func TestProxy_WaitCapturesAfterLargeResponse(t *testing.T) {
-	// WaitCaptures must account for a request whose response the client has
-	// already read. With registration happening after the response write, a
-	// body large enough to clear the write buffers lets the client return
-	// first, so WaitCaptures sees nothing pending and returns too early.
-	body := strings.Repeat("a", 64*1024)
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "text/plain")
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(body)))
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(body))
-	}))
-	defer upstream.Close()
-
-	writeDir := t.TempDir()
-	p, err := proxy.New(proxy.Config{
-		UpstreamURL:  upstream.URL,
-		WriteDir:     writeDir,
-		StripHeaders: []string{},
-		Dedupe:       "overwrite",
-	})
-	if err != nil {
-		t.Fatalf("failed to create proxy: %v", err)
-	}
-
-	if _, err := p.Start("127.0.0.1:0"); err != nil {
-		t.Fatalf("failed to start proxy: %v", err)
-	}
-	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
-
-	resp, err := httpClient.Get(p.URL() + "/large")
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	if _, err := io.Copy(io.Discard, resp.Body); err != nil {
-		t.Fatalf("reading body failed: %v", err)
-	}
-	_ = resp.Body.Close()
-
-	p.WaitCaptures()
-
-	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
-	if err != nil {
-		t.Fatalf("failed to glob: %v", err)
-	}
-	if len(files) != 1 {
-		t.Fatalf("WaitCaptures returned before the capture was written, got %d files", len(files))
-	}
-}
-
 func TestProxy_PrettyJSON_DropsContentLength(t *testing.T) {
 	// Pretty-printing changes the body length, so the upstream's Content-Length
 	// no longer describes the captured body and must not be recorded.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1021,11 +1021,9 @@ func TestProxy_ConcurrentCapturesSameBaseName(t *testing.T) {
 	// and race to write it. Whichever wins, the file must be a complete coat --
 	// never one response's prefix followed by the other's tail.
 	//
-	// os.WriteFile is open(O_TRUNC) then write, and nothing pairs the truncate
-	// with the write: two of them on one path can interleave as A-open, B-open
-	// (truncating), A-write, B-write, leaving B's bytes over the head of A's.
-	// The writes must therefore be atomic with respect to each other, which is
-	// what writing to a temp file and renaming buys.
+	// Two things combine to give that: writes go to a temp file and are renamed
+	// into place, which is atomic, and captures resolving to the same name are
+	// serialised so they do not share that temp file.
 	//
 	// Both responses are the same size and both requests are released together,
 	// so the two writes actually overlap. An earlier version of this test used
@@ -2073,5 +2071,123 @@ func TestProxy_ShutdownBeforeStartIsNotAnError(t *testing.T) {
 
 	if err := p.Shutdown(time.Second); err != nil {
 		t.Fatalf("Shutdown before Start should be a no-op, got %v", err)
+	}
+}
+
+func TestProxy_CaptureIsNeverVisiblePartiallyWritten(t *testing.T) {
+	// A coat file is read by other processes while the proxy is writing it --
+	// `trenchcoat serve --watch` pointed at the same directory is the obvious
+	// case, and `trenchcoat validate` the other. os.WriteFile truncates and then
+	// writes, so a reader that opens the file in between sees a prefix of the
+	// new content, or nothing at all, and a coat file half a response long is
+	// not valid YAML.
+	//
+	// Writing to a temp file and renaming makes the swap atomic: a reader sees
+	// either the whole previous capture or the whole new one.
+	body := strings.Repeat("A", 256*1024)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(10 * time.Second) })
+
+	coatPath := filepath.Join(writeDir, "GET_api_items_200.yaml")
+
+	// Poll the coat file the way a watching process would, and record any read
+	// that produced something unparseable or short.
+	stop := make(chan struct{})
+	var readerWG sync.WaitGroup
+	var mu sync.Mutex
+	var reads, bad int
+	var firstBad string
+
+	readerWG.Add(1)
+	go func() {
+		defer readerWG.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+
+			content, err := os.ReadFile(coatPath)
+			if err != nil {
+				continue // Not written yet; a missing file is not a torn one.
+			}
+
+			var parsed coat.File
+			problem := ""
+			switch {
+			case yaml.Unmarshal(content, &parsed) != nil:
+				problem = "not valid YAML"
+			case len(parsed.Coats) != 1:
+				problem = fmt.Sprintf("%d coats", len(parsed.Coats))
+			case parsed.Coats[0].Response == nil:
+				problem = "no response"
+			case len(parsed.Coats[0].Response.Body) != len(body):
+				problem = fmt.Sprintf("body is %d bytes, want %d", len(parsed.Coats[0].Response.Body), len(body))
+			}
+
+			mu.Lock()
+			reads++
+			if problem != "" {
+				bad++
+				if firstBad == "" {
+					firstBad = problem
+				}
+			}
+			mu.Unlock()
+		}
+	}()
+
+	// Keep the captures overlapping rather than waiting for each one: the window
+	// a reader can fall into is the write itself, so back-to-back rewrites are
+	// what make it reachable at all.
+	var clients sync.WaitGroup
+	for range 8 {
+		clients.Add(1)
+		go func() {
+			defer clients.Done()
+			for range 40 {
+				resp, err := httpClient.Get(p.URL() + "/api/items")
+				if err != nil {
+					return
+				}
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}
+		}()
+	}
+	clients.Wait()
+	p.WaitCaptures()
+
+	close(stop)
+	readerWG.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+	if reads == 0 {
+		t.Fatal("the reader never managed to read the coat file, so this proves nothing")
+	}
+	if bad > 0 {
+		t.Fatalf("%d of %d reads saw a partially written coat file (first: %s); a watching process would load a broken fixture",
+			bad, reads, firstBad)
 	}
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1041,86 +1041,6 @@ func TestProxy_PrettyJSON(t *testing.T) {
 	}
 }
 
-func TestProxy_ShutdownWritesInFlightCaptures(t *testing.T) {
-	// Captures are the entire point of proxy mode, so Ctrl-C must not drop the
-	// requests that were in flight when it arrived. Enough concurrent requests
-	// to queue behind the capture semaphore, all released at once, so captures
-	// are still pending when the HTTP drain finishes.
-	const requests = 30
-
-	release := make(chan struct{})
-	var arrived sync.WaitGroup
-	arrived.Add(requests)
-
-	// A large body so marshalling and writing each coat takes long enough that
-	// a Shutdown which does not wait for captures demonstrably returns first.
-	payload := `{"data": "` + strings.Repeat("x", 2*1024*1024) + `"}`
-
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		arrived.Done()
-		<-release
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte(payload))
-	}))
-	defer upstream.Close()
-
-	writeDir := t.TempDir()
-	p, err := proxy.New(proxy.Config{
-		UpstreamURL:  upstream.URL,
-		WriteDir:     writeDir,
-		StripHeaders: []string{},
-		Dedupe:       "overwrite",
-	})
-	if err != nil {
-		t.Fatalf("failed to create proxy: %v", err)
-	}
-
-	if _, err := p.Start("127.0.0.1:0"); err != nil {
-		t.Fatalf("failed to start proxy: %v", err)
-	}
-
-	var clients sync.WaitGroup
-	for i := 0; i < requests; i++ {
-		clients.Add(1)
-		go func(n int) {
-			defer clients.Done()
-			resp, err := httpClient.Get(fmt.Sprintf("%s/item/%d", p.URL(), n))
-			if err != nil {
-				return
-			}
-			_, _ = io.Copy(io.Discard, resp.Body)
-			_ = resp.Body.Close()
-		}(i)
-	}
-
-	// All requests are parked in the upstream handler, so no capture has been
-	// registered yet. Shutdown starts from that state -- the situation on
-	// Ctrl-C mid-request -- and only then are the handlers released.
-	arrived.Wait()
-
-	shutdownErr := make(chan error, 1)
-	go func() { shutdownErr <- p.Shutdown(30 * time.Second) }()
-	// Only long enough for Shutdown to reach its drain; http.Server.Shutdown
-	// polls for idle connections on a backing-off interval, so a longer pause
-	// here would let it sleep through the window this test is aiming at.
-	time.Sleep(10 * time.Millisecond)
-	close(release)
-
-	if err := <-shutdownErr; err != nil {
-		t.Fatalf("shutdown failed: %v", err)
-	}
-	clients.Wait()
-
-	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
-	if err != nil {
-		t.Fatalf("failed to glob: %v", err)
-	}
-	if len(files) != requests {
-		t.Fatalf("shutdown returned with %d of %d captures written; the rest were lost", len(files), requests)
-	}
-}
-
 func TestProxy_ConcurrentCapturesSameBaseName(t *testing.T) {
 	// The query string is deliberately excluded from the generated base name, so
 	// two concurrent requests differing only by query resolve to one filename
@@ -1195,11 +1115,22 @@ func truncate(s string, n int) string {
 }
 
 func TestProxy_DedupeSkip_ConcurrentSameRequest(t *testing.T) {
-	// 'skip' promises one file per distinct request. The existence check runs
-	// under the lock but the write does not, so concurrent captures of the same
-	// request can all pass the check; they converge on one filename because the
-	// name carries a one-second-resolution timestamp. Pin both halves of that:
-	// one file, and its contents intact.
+	// 'skip' promises one file per distinct request, and must keep that promise
+	// when the captures are concurrent.
+	//
+	// This reproduces the pre-fix bug intermittently, not reliably: roughly one
+	// run in four under -race. Every capture asks whether a file already exists
+	// and then writes, and if the check and the write are not one atomic step
+	// they all see an empty directory. The generated name is stamped with the
+	// current second, so they still converge on a single path unless the batch
+	// happens to straddle a second boundary -- which is what makes it a coin
+	// toss rather than a proof. Aligning the release to the boundary does not
+	// help, because the delay between releasing a request and its capture
+	// choosing a name varies by more than the window being aimed at.
+	//
+	// It is kept because it did catch the real thing (two files, timestamps one
+	// second apart) and because the invariant is worth stating, but it is not
+	// load-bearing: the lock is.
 	const requests = 16
 
 	// Hold every request in the upstream until all of them have arrived, so the

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -679,49 +679,23 @@ func TestProxy_InvalidGzipBody(t *testing.T) {
 }
 
 func TestProxy_Filter_InvalidPattern(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		_, _ = w.Write([]byte("ok"))
-	}))
-	defer upstream.Close()
-
-	writeDir := t.TempDir()
-	p, err := proxy.New(proxy.Config{
-		UpstreamURL:  upstream.URL,
-		WriteDir:     writeDir,
+	// A filter that cannot compile used to be accepted, then rejected every
+	// request inside shouldCapture: one error logged per request, nothing
+	// captured, and --verbose reporting "captured=false" exactly as it would
+	// for a deliberate filter miss. Rejecting it at construction says so once,
+	// before anything is proxied.
+	_, err := proxy.New(proxy.Config{
+		UpstreamURL:  "http://127.0.0.1:1",
+		WriteDir:     t.TempDir(),
 		Filter:       "[invalid-pattern", // Malformed glob — unclosed bracket.
 		StripHeaders: []string{},
 		Dedupe:       "overwrite",
 	})
-	if err != nil {
-		t.Fatalf("failed to create proxy: %v", err)
+	if err == nil {
+		t.Fatal("expected proxy.New to reject an uncompilable --filter pattern")
 	}
-
-	_, err = p.Start("127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("failed to start proxy: %v", err)
-	}
-	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
-
-	// Request should still succeed (proxied to upstream).
-	resp, err := httpClient.Get(p.URL() + "/test")
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
-	}
-	_ = resp.Body.Close()
-	if resp.StatusCode != 200 {
-		t.Fatalf("expected 200, got %d", resp.StatusCode)
-	}
-
-	p.WaitCaptures()
-
-	// No coat file should be captured — shouldCapture returns false on error.
-	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
-	if err != nil {
-		t.Fatalf("failed to glob: %v", err)
-	}
-	if len(files) != 0 {
-		t.Fatalf("expected no captured files with invalid filter, got %d", len(files))
+	if !strings.Contains(err.Error(), "[invalid-pattern") {
+		t.Fatalf("error should name the offending pattern, got: %v", err)
 	}
 }
 
@@ -1047,18 +1021,29 @@ func TestProxy_ConcurrentCapturesSameBaseName(t *testing.T) {
 	// and race to write it. Whichever wins, the file must be a complete coat --
 	// never one response's prefix followed by the other's tail.
 	//
-	// This holds today because os.WriteFile issues a single write syscall and
-	// the kernel serialises writes to a regular file. It is an invariant worth
-	// pinning: chunking the write, or switching to an io.Writer, would break it
-	// silently and leave unparseable fixtures behind.
+	// os.WriteFile is open(O_TRUNC) then write, and nothing pairs the truncate
+	// with the write: two of them on one path can interleave as A-open, B-open
+	// (truncating), A-write, B-write, leaving B's bytes over the head of A's.
+	// The writes must therefore be atomic with respect to each other, which is
+	// what writing to a temp file and renaming buys.
+	//
+	// Both responses are the same size and both requests are released together,
+	// so the two writes actually overlap. An earlier version of this test used
+	// 200 KiB against 64 B, which kept the captures tens of milliseconds apart
+	// and hid the race completely.
 	long := strings.Repeat("A", 200*1024)
-	short := strings.Repeat("B", 64)
+	short := strings.Repeat("B", 200*1024)
+
+	release := make(chan struct{})
+	var arrived sync.WaitGroup
 
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body := short
 		if r.URL.Query().Get("page") == "1" {
 			body = long
 		}
+		arrived.Done()
+		<-release
 		w.Header().Set("Content-Type", "text/plain")
 		w.WriteHeader(200)
 		_, _ = w.Write([]byte(body))
@@ -1082,6 +1067,9 @@ func TestProxy_ConcurrentCapturesSameBaseName(t *testing.T) {
 	t.Cleanup(func() { _ = p.Shutdown(10 * time.Second) })
 
 	for range 40 {
+		release = make(chan struct{})
+		arrived.Add(2)
+
 		var wg sync.WaitGroup
 		for _, page := range []string{"1", "2"} {
 			wg.Add(1)
@@ -1095,6 +1083,12 @@ func TestProxy_ConcurrentCapturesSameBaseName(t *testing.T) {
 				_ = resp.Body.Close()
 			}(page)
 		}
+
+		// Both handlers are parked in the upstream; release them together so the
+		// two captures reach their writes at the same moment.
+		arrived.Wait()
+		close(release)
+
 		wg.Wait()
 		p.WaitCaptures()
 
@@ -1840,5 +1834,70 @@ func TestProxy_DropsHeadersNamedInConnection(t *testing.T) {
 
 	if got := resp.Header.Get("X-Internal-Backend"); got != "" {
 		t.Errorf("X-Internal-Backend was scoped to this hop by the upstream's Connection header but reached the client as %q", got)
+	}
+}
+
+func TestProxy_CaptureOmitsConnectionScopedHeaders(t *testing.T) {
+	// A header a peer scopes to this hop via Connection is withheld from the
+	// wire in both directions -- so it must not be recorded either. Capturing
+	// the request one makes it a replay match constraint for a header the
+	// upstream provably never saw; capturing the response one makes the mock
+	// serve a header the proxy itself refused to relay, and `Connection: close`
+	// then kills keep-alive for every replay client.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Connection", "X-Internal-Backend")
+		w.Header().Set("X-Internal-Backend", "pod-7")
+		w.Header().Set("Keep-Alive", "timeout=5")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":1}`))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	req, err := http.NewRequest("GET", p.URL()+"/hop", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Connection", "keep-alive, X-Trace-Token")
+	req.Header.Set("X-Trace-Token", "secret")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	captured := readOnlyCoat(t, writeDir)
+
+	if got, ok := captured.Coats[0].Request.Headers["X-Trace-Token"]; ok {
+		t.Errorf("captured request headers include X-Trace-Token=%q, which the client scoped to this hop and the upstream never received", got)
+	}
+	for name := range captured.Coats[0].Response.Headers {
+		switch {
+		case strings.EqualFold(name, "Connection"),
+			strings.EqualFold(name, "Keep-Alive"),
+			strings.EqualFold(name, "X-Internal-Backend"):
+			t.Errorf("captured response headers include %s, which the proxy withheld from the client", name)
+		}
+	}
+	if got := captured.Coats[0].Response.Headers["Content-Type"]; got != "application/json" {
+		t.Errorf("Content-Type must still be captured, got %q", got)
 	}
 }

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1121,6 +1121,154 @@ func TestProxy_ShutdownWritesInFlightCaptures(t *testing.T) {
 	}
 }
 
+func TestProxy_ConcurrentCapturesSameBaseName(t *testing.T) {
+	// The query string is deliberately excluded from the generated base name, so
+	// two concurrent requests differing only by query resolve to one filename
+	// and race to write it. Whichever wins, the file must be a complete coat --
+	// never one response's prefix followed by the other's tail.
+	//
+	// This holds today because os.WriteFile issues a single write syscall and
+	// the kernel serialises writes to a regular file. It is an invariant worth
+	// pinning: chunking the write, or switching to an io.Writer, would break it
+	// silently and leave unparseable fixtures behind.
+	long := strings.Repeat("A", 200*1024)
+	short := strings.Repeat("B", 64)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := short
+		if r.URL.Query().Get("page") == "1" {
+			body = long
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(10 * time.Second) })
+
+	for range 40 {
+		var wg sync.WaitGroup
+		for _, page := range []string{"1", "2"} {
+			wg.Add(1)
+			go func(page string) {
+				defer wg.Done()
+				resp, err := httpClient.Get(p.URL() + "/api/items?page=" + page)
+				if err != nil {
+					return
+				}
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}(page)
+		}
+		wg.Wait()
+		p.WaitCaptures()
+
+		captured := readOnlyCoat(t, writeDir)
+		body := captured.Coats[0].Response.Body
+		if body != long && body != short {
+			t.Fatalf("captured coat body is neither response intact: %d bytes, starts %q, ends %q",
+				len(body), truncate(body, 16), truncate(body[max(0, len(body)-16):], 16))
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}
+
+func TestProxy_DedupeSkip_ConcurrentSameRequest(t *testing.T) {
+	// 'skip' promises one file per distinct request. The existence check runs
+	// under the lock but the write does not, so concurrent captures of the same
+	// request can all pass the check; they converge on one filename because the
+	// name carries a one-second-resolution timestamp. Pin both halves of that:
+	// one file, and its contents intact.
+	const requests = 16
+
+	// Hold every request in the upstream until all of them have arrived, so the
+	// captures start together and genuinely overlap. Without this the first
+	// capture finishes before the next request is even made, and the check and
+	// the write never interleave. The body is large enough that marshalling and
+	// writing it takes long enough to matter.
+	release := make(chan struct{})
+	var arrived sync.WaitGroup
+	arrived.Add(requests)
+	body := strings.Repeat("C", 512*1024)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		arrived.Done()
+		<-release
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(body))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "skip",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(10 * time.Second) })
+
+	var wg sync.WaitGroup
+	for range requests {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := httpClient.Get(p.URL() + "/api/items")
+			if err != nil {
+				return
+			}
+			_, _ = io.Copy(io.Discard, resp.Body)
+			_ = resp.Body.Close()
+		}()
+	}
+	arrived.Wait()
+	close(release)
+	wg.Wait()
+	p.WaitCaptures()
+
+	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
+	if err != nil {
+		t.Fatalf("failed to glob: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("dedupe=skip wrote %d files for the same request, want 1: %v", len(files), files)
+	}
+
+	captured := readOnlyCoat(t, writeDir)
+	if got := captured.Coats[0].Response.Body; got != body {
+		t.Fatalf("captured body is torn: got %d bytes, want %d", len(got), len(body))
+	}
+}
+
 func TestProxy_PrettyJSON_DropsContentLength(t *testing.T) {
 	// Pretty-printing changes the body length, so the upstream's Content-Length
 	// no longer describes the captured body and must not be recorded.

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1695,3 +1695,137 @@ func TestProxy_PreservesPercentEncodedPath(t *testing.T) {
 		t.Fatalf("upstream saw %q, want %q -- the encoded separator was decoded in transit", got, "/seg%2Fment/tail")
 	}
 }
+
+func TestProxy_CaptureOmitsClientSpecificHeaders(t *testing.T) {
+	// Captured request headers become mandatory match constraints at replay, so
+	// anything the client happened to send -- its User-Agent, its content
+	// negotiation, the transport's Accept-Encoding -- silently ties the coat to
+	// the tool that recorded it. Headers that genuinely qualify the request must
+	// still be kept.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"ok":1}`))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	req, err := http.NewRequest("POST", p.URL()+"/api/users", strings.NewReader(`{"n":1}`))
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("User-Agent", "curl/8.7.1")
+	req.Header.Set("Accept", "*/*")
+	req.Header.Set("Accept-Language", "en-AU")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", "abc123")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	captured := readOnlyCoat(t, writeDir)
+	headers := captured.Coats[0].Request.Headers
+
+	for _, unwanted := range []string{"User-Agent", "Accept", "Accept-Encoding", "Accept-Language", "Host", "Content-Length", "Connection"} {
+		for k := range headers {
+			if strings.EqualFold(k, unwanted) {
+				t.Errorf("captured coat records %s: %q, which ties the coat to the client that recorded it", k, headers[k])
+			}
+		}
+	}
+
+	if got := headers["Content-Type"]; got != "application/json" {
+		t.Errorf("Content-Type qualifies the request and must be kept, got %q", got)
+	}
+	if got := headers["X-Api-Key"]; got != "abc123" {
+		t.Errorf("custom headers qualify the request and must be kept, got %q", got)
+	}
+}
+
+func TestProxy_CapturedCoatReplaysFromAnotherClient(t *testing.T) {
+	// The end-to-end consequence: a coat captured from one tool must serve a
+	// request made by a different one.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"users":[]}`))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	req, err := http.NewRequest("GET", p.URL()+"/api/users", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("User-Agent", "curl/8.7.1")
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("capture request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected a captured coat, glob err %v files %v", err, files)
+	}
+	loaded, errs := coat.LoadPaths([]string{files[0]})
+	if len(errs) > 0 {
+		t.Fatalf("captured coat did not load: %v", errs)
+	}
+
+	mock := server.New(loaded, server.Config{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+	addr, err := mock.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start mock: %v", err)
+	}
+	t.Cleanup(func() { _ = mock.Shutdown(5 * time.Second) })
+
+	replayReq, err := http.NewRequest("GET", "http://"+addr+"/api/users", nil)
+	if err != nil {
+		t.Fatalf("failed to build replay request: %v", err)
+	}
+	replayReq.Header.Set("User-Agent", "some-other-tool/2.0")
+	replayed, err := httpClient.Do(replayReq)
+	if err != nil {
+		t.Fatalf("replay request failed: %v", err)
+	}
+	defer func() { _ = replayed.Body.Close() }()
+
+	if replayed.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(replayed.Body)
+		t.Fatalf("replaying a captured coat from a different client got %d: %s", replayed.StatusCode, body)
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1789,3 +1789,56 @@ func TestProxy_CapturedCoatReplaysFromAnotherClient(t *testing.T) {
 		t.Fatalf("replaying a captured coat from a different client got %d: %s", replayed.StatusCode, body)
 	}
 }
+
+func TestProxy_DropsHeadersNamedInConnection(t *testing.T) {
+	// RFC 9110 7.6.1: the Connection header lists headers that are scoped to
+	// this hop only. Filtering just the static hop-by-hop set forwards them
+	// anyway, in both directions.
+	sawUpstream := make(chan http.Header, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawUpstream <- r.Header.Clone()
+		w.Header().Set("Connection", "X-Internal-Backend")
+		w.Header().Set("X-Internal-Backend", "pod-7")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     t.TempDir(),
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	req, err := http.NewRequest("GET", p.URL()+"/hop", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	req.Header.Set("Connection", "keep-alive, X-Trace-Token")
+	req.Header.Set("X-Trace-Token", "secret")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	p.WaitCaptures()
+
+	upstreamHeaders := <-sawUpstream
+	if got := upstreamHeaders.Get("X-Trace-Token"); got != "" {
+		t.Errorf("X-Trace-Token was scoped to this hop by the client's Connection header but reached the upstream as %q", got)
+	}
+
+	if got := resp.Header.Get("X-Internal-Backend"); got != "" {
+		t.Errorf("X-Internal-Backend was scoped to this hop by the upstream's Connection header but reached the client as %q", got)
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1653,3 +1653,45 @@ func TestProxyShutdownRespectsTimeoutWithPendingCaptures(t *testing.T) {
 		t.Fatal("Shutdown did not return within timeout")
 	}
 }
+
+func TestProxy_PreservesPercentEncodedPath(t *testing.T) {
+	// The proxy rebuilt the upstream URL from the decoded r.URL.Path, so an
+	// encoded separator was handed to the upstream as a real one and reached a
+	// different route than the client asked for. A capture tool that quietly
+	// rewrites the request is recording something that never happened.
+	seen := make(chan string, 1)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.RequestURI
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer upstream.Close()
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     t.TempDir(),
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get(p.URL() + "/seg%2Fment/tail")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	got := <-seen
+	if got != "/seg%2Fment/tail" {
+		t.Fatalf("upstream saw %q, want %q -- the encoded separator was decoded in transit", got, "/seg%2Fment/tail")
+	}
+}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1604,54 +1604,14 @@ func TestProxyCapturesConcurrencyBounded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(files) == 0 {
-		t.Fatal("expected captured coat files, got none")
-	}
-	if len(files) < 20 {
-		t.Errorf("expected at least 20 coat files, got %d", len(files))
+	// Exactly one file per request. A floor of 20 would let a third of the
+	// captures go missing -- to a filename collision, or a write error swallowed
+	// by the capture path -- and still report success.
+	if len(files) != numRequests {
+		t.Errorf("expected %d coat files, one per request, got %d", numRequests, len(files))
 	}
 
 	_ = p.Shutdown(5 * time.Second)
-}
-
-func TestProxyShutdownRespectsTimeoutWithPendingCaptures(t *testing.T) {
-	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
-		_, _ = fmt.Fprint(w, "ok")
-	}))
-	defer upstream.Close()
-
-	writeDir := t.TempDir()
-
-	p, err := proxy.New(proxy.Config{
-		UpstreamURL: upstream.URL,
-		WriteDir:    writeDir,
-		Logger:      slog.New(slog.NewTextHandler(io.Discard, nil)),
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr, err := p.Start("127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	resp, err := http.Get("http://" + addr + "/test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	_ = resp.Body.Close()
-
-	done := make(chan error, 1)
-	go func() {
-		done <- p.Shutdown(500 * time.Millisecond)
-	}()
-
-	select {
-	case <-done:
-	case <-time.After(3 * time.Second):
-		t.Fatal("Shutdown did not return within timeout")
-	}
 }
 
 func TestProxy_PreservesPercentEncodedPath(t *testing.T) {

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -1553,7 +1553,12 @@ func TestProxy_NameTemplate(t *testing.T) {
 	}
 }
 
-func TestProxyCapturesConcurrencyBounded(t *testing.T) {
+// TestProxy_EveryRequestProducesOneCapture checks capture completeness under
+// concurrency: 30 distinct paths must yield 30 coat files. It does not test
+// captureSem -- deleting the semaphore leaves it green, because nothing here
+// observes how many captures run at once. TestProxy_CaptureConcurrencyIsBounded
+// covers that.
+func TestProxy_EveryRequestProducesOneCapture(t *testing.T) {
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(200)
 		_, _ = fmt.Fprint(w, "ok")
@@ -1598,9 +1603,8 @@ func TestProxyCapturesConcurrencyBounded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// Exactly one file per request. A floor of 20 would let a third of the
-	// captures go missing -- to a filename collision, or a write error swallowed
-	// by the capture path -- and still report success.
+	// Exactly one file per request: a lower-bound assertion would tolerate
+	// captures silently lost to a filename collision or a swallowed write error.
 	if len(files) != numRequests {
 		t.Errorf("expected %d coat files, one per request, got %d", numRequests, len(files))
 	}
@@ -1609,10 +1613,9 @@ func TestProxyCapturesConcurrencyBounded(t *testing.T) {
 }
 
 func TestProxy_PreservesPercentEncodedPath(t *testing.T) {
-	// The proxy rebuilt the upstream URL from the decoded r.URL.Path, so an
-	// encoded separator was handed to the upstream as a real one and reached a
-	// different route than the client asked for. A capture tool that quietly
-	// rewrites the request is recording something that never happened.
+	// An encoded separator must reach the upstream as the client wrote it. A
+	// capture tool that rewrites the request in transit records something that
+	// never happened.
 	seen := make(chan string, 1)
 	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		seen <- r.RequestURI
@@ -1698,7 +1701,12 @@ func TestProxy_CaptureOmitsClientSpecificHeaders(t *testing.T) {
 	captured := readOnlyCoat(t, writeDir)
 	headers := captured.Coats[0].Request.Headers
 
-	for _, unwanted := range []string{"User-Agent", "Accept", "Accept-Encoding", "Accept-Language", "Host", "Content-Length", "Connection"} {
+	// Host and Connection are deliberately absent from this list. net/http moves
+	// the host to r.Host and deletes it from r.Header, and this client sends no
+	// Connection header, so neither could fail here regardless of what the
+	// capture path does. Connection-scoped headers are covered by
+	// TestProxy_CaptureOmitsConnectionScopedHeaders.
+	for _, unwanted := range []string{"User-Agent", "Accept", "Accept-Encoding", "Accept-Language", "Content-Length"} {
 		for k := range headers {
 			if strings.EqualFold(k, unwanted) {
 				t.Errorf("captured coat records %s: %q, which ties the coat to the client that recorded it", k, headers[k])

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/yesdevnull/trenchcoat/internal/coat"
 	"github.com/yesdevnull/trenchcoat/internal/proxy"
+	"github.com/yesdevnull/trenchcoat/internal/server"
 )
 
 // httpClient is a shared test client with an explicit timeout to prevent
@@ -1038,6 +1039,150 @@ func TestProxy_PrettyJSON(t *testing.T) {
 	if body != pretty.String() {
 		t.Fatalf("expected pretty-printed JSON body:\n%s\n\ngot:\n%s\n\nfull coat file:\n%s", pretty.String(), body, contentStr)
 	}
+}
+
+func TestProxy_PrettyJSON_DropsContentLength(t *testing.T) {
+	// Pretty-printing changes the body length, so the upstream's Content-Length
+	// no longer describes the captured body and must not be recorded.
+	compactJSON := `{"users":[{"id":1,"name":"alice"},{"id":2,"name":"bob"}]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(compactJSON)))
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(compactJSON))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+		PrettyJSON:   true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get(p.URL() + "/api/users")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	captured := readOnlyCoat(t, writeDir)
+	for k, v := range captured.Coats[0].Response.Headers {
+		if strings.EqualFold(k, "Content-Length") {
+			t.Fatalf("captured coat kept Content-Length %q, which no longer matches the pretty-printed body of %d bytes",
+				v, len(captured.Coats[0].Response.Body))
+		}
+	}
+}
+
+func TestProxy_PrettyJSON_CapturedCoatReplays(t *testing.T) {
+	// The point of capturing is replay: serving the captured coat must return
+	// the whole pretty-printed body, not a body truncated to a stale length.
+	compactJSON := `{"users":[{"id":1,"name":"alice"},{"id":2,"name":"bob"}]}`
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", len(compactJSON)))
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(compactJSON))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+		PrettyJSON:   true,
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+	t.Cleanup(func() { _ = p.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get(p.URL() + "/api/users")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	p.WaitCaptures()
+
+	files, err := filepath.Glob(filepath.Join(writeDir, "*.yaml"))
+	if err != nil || len(files) == 0 {
+		t.Fatalf("expected a captured coat file, glob err %v, files %v", err, files)
+	}
+
+	loaded, errs := coat.LoadPaths([]string{files[0]})
+	if len(errs) > 0 {
+		t.Fatalf("captured coat did not load: %v", errs)
+	}
+
+	mock := server.New(loaded, server.Config{Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
+	addr, err := mock.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start mock: %v", err)
+	}
+	t.Cleanup(func() { _ = mock.Shutdown(5 * time.Second) })
+
+	replayed, err := httpClient.Get("http://" + addr + "/api/users")
+	if err != nil {
+		t.Fatalf("replay request failed: %v", err)
+	}
+	defer func() { _ = replayed.Body.Close() }()
+
+	body, err := io.ReadAll(replayed.Body)
+	if err != nil {
+		t.Fatalf("reading replayed body failed: %v", err)
+	}
+
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, []byte(compactJSON), "", "  "); err != nil {
+		t.Fatalf("failed to indent JSON: %v", err)
+	}
+	if string(body) != pretty.String() {
+		t.Fatalf("replaying the captured coat returned %d bytes, want the %d-byte pretty body\ngot:  %q\nwant: %q",
+			len(body), pretty.Len(), string(body), pretty.String())
+	}
+}
+
+// readOnlyCoat parses the single captured coat file in dir, failing if there is
+// not exactly one.
+func readOnlyCoat(t *testing.T, dir string) coat.File {
+	t.Helper()
+
+	files, err := filepath.Glob(filepath.Join(dir, "*.yaml"))
+	if err != nil {
+		t.Fatalf("failed to glob: %v", err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected exactly one captured coat file, got %v", files)
+	}
+
+	content, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", files[0], err)
+	}
+
+	var parsed coat.File
+	if err := yaml.Unmarshal(content, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal %s: %v", files[0], err)
+	}
+	return parsed
 }
 
 func TestProxy_PrettyJSON_NonJSON(t *testing.T) {

--- a/internal/proxy/shutdown_unix_test.go
+++ b/internal/proxy/shutdown_unix_test.go
@@ -92,6 +92,22 @@ func TestProxy_ShutdownWaitsForCaptureFromInFlightRequest(t *testing.T) {
 		}
 		_, _ = io.Copy(io.Discard, fifo)
 		_ = fifo.Close()
+
+		// The capture this test deliberately abandons is now released, and its
+		// next move is to rename its temp file into the write directory that
+		// t.TempDir's cleanup -- registered earlier, so running later -- is
+		// about to remove. Wait for it, or that removal can fail with
+		// "directory not empty". The sibling test below guards the same hazard.
+		captures := make(chan struct{})
+		go func() {
+			p.WaitCaptures()
+			close(captures)
+		}()
+		select {
+		case <-captures:
+		case <-time.After(30 * time.Second):
+			t.Error("timed out waiting for the released capture to finish")
+		}
 	})
 
 	client := &http.Client{Timeout: 30 * time.Second}

--- a/internal/proxy/shutdown_unix_test.go
+++ b/internal/proxy/shutdown_unix_test.go
@@ -130,3 +130,107 @@ func TestProxy_ShutdownWaitsForCaptureFromInFlightRequest(t *testing.T) {
 			elapsed.Round(time.Millisecond), captureDrain)
 	}
 }
+
+// TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain covers the case
+// the ordering fix left open.
+//
+// http.Server.Shutdown returns ctx.Err() when its deadline passes with
+// connections still active, and it does not stop the handlers running on them.
+// Waiting on the capture group at that point is the very race the ordering fix
+// was meant to close: a handler still in flight can call captures.Go while
+// Wait is in progress, and Add concurrent with Wait is documented WaitGroup
+// misuse that panics.
+//
+// The panic itself needs an interleaving too narrow to force reliably, so this
+// pins the observable half. With a capture parked on a FIFO, a Shutdown that
+// goes on to wait spends its whole capture-drain budget; one that correctly
+// declines to wait returns as soon as the HTTP drain gives up.
+func TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain(t *testing.T) {
+	const (
+		shutdownTimeout = 2 * time.Second
+		httpDrain       = shutdownTimeout / 2
+	)
+
+	parked := make(chan struct{})
+	var parkedArrived sync.WaitGroup
+	parkedArrived.Add(1)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/parked" {
+			parkedArrived.Done()
+			<-parked
+		}
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("captured"))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+	coatPath := filepath.Join(writeDir, "GET_blocked_200.yaml")
+	if err := syscall.Mkfifo(coatPath, 0600); err != nil {
+		t.Fatalf("failed to create fifo at %s: %v", coatPath, err)
+	}
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+		Logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	// One capture that can never finish, so the capture group stays non-empty.
+	resp, err := client.Get(p.URL() + "/blocked")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	_ = resp.Body.Close()
+
+	// One request that never returns, so the HTTP drain must time out.
+	var parkedRequest sync.WaitGroup
+	parkedRequest.Add(1)
+	go func() {
+		defer parkedRequest.Done()
+		resp, err := client.Get(p.URL() + "/parked")
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+	parkedArrived.Wait()
+
+	// Let the blocked capture reach its write before shutting down.
+	time.Sleep(100 * time.Millisecond)
+
+	started := time.Now()
+	shutdownErr := p.Shutdown(shutdownTimeout)
+	elapsed := time.Since(started)
+
+	// Release everything before asserting, so a failure cannot hang the suite.
+	close(parked)
+	fifo, ferr := os.OpenFile(coatPath, os.O_RDONLY, 0)
+	if ferr == nil {
+		_, _ = io.Copy(io.Discard, fifo)
+		_ = fifo.Close()
+	}
+	parkedRequest.Wait()
+
+	if shutdownErr == nil {
+		t.Fatal("expected Shutdown to report the HTTP drain deadline")
+	}
+	if elapsed > httpDrain+500*time.Millisecond {
+		t.Fatalf("Shutdown took %s: after the HTTP drain failed it went on to wait for captures, which races captures.Go in the handlers still running",
+			elapsed.Round(time.Millisecond))
+	}
+}

--- a/internal/proxy/shutdown_unix_test.go
+++ b/internal/proxy/shutdown_unix_test.go
@@ -1,0 +1,132 @@
+//go:build unix
+
+package proxy_test
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/yesdevnull/trenchcoat/internal/proxy"
+)
+
+// TestProxy_ShutdownWaitsForCaptureFromInFlightRequest pins the ordering of the
+// two drains in Shutdown.
+//
+// Waiting on the capture group before stopping the HTTP server loses the
+// captures belonging to requests that were still in flight: the wait finds an
+// empty group and returns at once, and the handlers that follow register their
+// captures with nothing left to wait for them. Pressing Ctrl-C mid-request then
+// silently discards exactly the coat files the user was recording.
+//
+// Timing cannot decide this. The window is however long the outstanding capture
+// work happens to take against however long http.Server.Shutdown happens to
+// take to notice idle connections, and tuning payload sizes against that only
+// produces a test that catches the bug some of the time. Instead the capture is
+// blocked outright: a FIFO sits at the path the capture will write to, and
+// os.WriteFile blocks there until something opens the read end. The correct
+// ordering must therefore burn its whole capture-drain budget, while the broken
+// ordering returns as soon as the connections are idle. That is a difference of
+// a second, not of microseconds, and it does not depend on load.
+//
+// Unix-only: it needs mkfifo. CI runs the suite on ubuntu-latest.
+func TestProxy_ShutdownWaitsForCaptureFromInFlightRequest(t *testing.T) {
+	const (
+		shutdownTimeout = 2 * time.Second
+		captureDrain    = shutdownTimeout / 2
+	)
+
+	release := make(chan struct{})
+	var arrived sync.WaitGroup
+	arrived.Add(1)
+
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		arrived.Done()
+		<-release
+		w.Header().Set("Content-Type", "text/plain")
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte("captured"))
+	}))
+	defer upstream.Close()
+
+	writeDir := t.TempDir()
+
+	// With dedupe=overwrite the capture path is fully determined: METHOD,
+	// sanitised URL path, status. Put a FIFO there so the write blocks.
+	coatPath := filepath.Join(writeDir, "GET_blocked_200.yaml")
+	if err := syscall.Mkfifo(coatPath, 0600); err != nil {
+		t.Fatalf("failed to create fifo at %s: %v", coatPath, err)
+	}
+
+	p, err := proxy.New(proxy.Config{
+		UpstreamURL:  upstream.URL,
+		WriteDir:     writeDir,
+		StripHeaders: []string{},
+		Dedupe:       "overwrite",
+		// The correct ordering logs a capture-drain timeout here by design;
+		// discard it rather than let it dirty the test output.
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("failed to create proxy: %v", err)
+	}
+
+	if _, err := p.Start("127.0.0.1:0"); err != nil {
+		t.Fatalf("failed to start proxy: %v", err)
+	}
+
+	// Unblock the capture goroutine at the end, whatever happens, so it does not
+	// outlive the test parked in a write.
+	t.Cleanup(func() {
+		fifo, err := os.OpenFile(coatPath, os.O_RDONLY|syscall.O_NONBLOCK, 0)
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, fifo)
+		_ = fifo.Close()
+	})
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	var request sync.WaitGroup
+	request.Add(1)
+	go func() {
+		defer request.Done()
+		resp, err := client.Get(p.URL() + "/blocked")
+		if err != nil {
+			return
+		}
+		_, _ = io.Copy(io.Discard, resp.Body)
+		_ = resp.Body.Close()
+	}()
+
+	// The request is parked in the upstream, so no capture has registered yet:
+	// this is the state Shutdown finds on Ctrl-C mid-request.
+	arrived.Wait()
+
+	shutdownErr := make(chan error, 1)
+	started := time.Now()
+	go func() { shutdownErr <- p.Shutdown(shutdownTimeout) }()
+	time.Sleep(10 * time.Millisecond)
+	close(release)
+
+	if err := <-shutdownErr; err != nil {
+		t.Fatalf("shutdown failed: %v", err)
+	}
+	elapsed := time.Since(started)
+	request.Wait()
+
+	// Blocked on the FIFO, the capture can never finish, so a Shutdown that
+	// waits for it must spend its whole capture-drain budget. Returning early
+	// means it never waited, and a real capture would have been lost.
+	if elapsed < captureDrain {
+		t.Fatalf("Shutdown returned after %s without waiting for the capture registered by the in-flight request; expected it to wait out the %s capture drain",
+			elapsed.Round(time.Millisecond), captureDrain)
+	}
+}

--- a/internal/proxy/shutdown_unix_test.go
+++ b/internal/proxy/shutdown_unix_test.go
@@ -108,7 +108,7 @@ func TestProxy_ShutdownWaitsForCaptureFromInFlightRequest(t *testing.T) {
 
 	// The request is parked in the upstream, so no capture has registered yet:
 	// this is the state Shutdown finds on Ctrl-C mid-request.
-	arrived.Wait()
+	waitOrFail(t, &arrived, 30*time.Second, "the request to reach the upstream")
 
 	shutdownErr := make(chan error, 1)
 	started := time.Now()
@@ -120,7 +120,7 @@ func TestProxy_ShutdownWaitsForCaptureFromInFlightRequest(t *testing.T) {
 		t.Fatalf("shutdown failed: %v", err)
 	}
 	elapsed := time.Since(started)
-	request.Wait()
+	waitOrFail(t, &request, 30*time.Second, "the client request to finish")
 
 	// Blocked on the FIFO, the capture can never finish, so a Shutdown that
 	// waits for it must spend its whole capture-drain budget. Returning early
@@ -138,8 +138,9 @@ func TestProxy_ShutdownWaitsForCaptureFromInFlightRequest(t *testing.T) {
 // connections still active, and it does not stop the handlers running on them.
 // Waiting on the capture group at that point is the very race the ordering fix
 // was meant to close: a handler still in flight can call captures.Go while
-// Wait is in progress, and Add concurrent with Wait is documented WaitGroup
-// misuse that panics.
+// Wait is in progress, and an Add that takes the counter from zero to positive
+// during a Wait is documented WaitGroup misuse that panics when the
+// interleaving lands.
 //
 // The panic itself needs an interleaving too narrow to force reliably, so this
 // pins the observable half. With a capture parked on a FIFO, a Shutdown that
@@ -208,7 +209,7 @@ func TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain(t *testing.T) {
 		_, _ = io.Copy(io.Discard, resp.Body)
 		_ = resp.Body.Close()
 	}()
-	parkedArrived.Wait()
+	waitOrFail(t, &parkedArrived, 30*time.Second, "the parked request to reach the upstream")
 
 	// Let the blocked capture reach its write before shutting down.
 	time.Sleep(100 * time.Millisecond)
@@ -224,7 +225,7 @@ func TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain(t *testing.T) {
 		_, _ = io.Copy(io.Discard, fifo)
 		_ = fifo.Close()
 	}
-	parkedRequest.Wait()
+	waitOrFail(t, &parkedRequest, 30*time.Second, "the parked request to finish")
 
 	if shutdownErr == nil {
 		t.Fatal("expected Shutdown to report the HTTP drain deadline")
@@ -232,5 +233,25 @@ func TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain(t *testing.T) {
 	if elapsed > httpDrain+500*time.Millisecond {
 		t.Fatalf("Shutdown took %s: after the HTTP drain failed it went on to wait for captures, which races captures.Go in the handlers still running",
 			elapsed.Round(time.Millisecond))
+	}
+}
+
+// waitOrFail waits for wg, failing instead of blocking the whole package if the
+// requests never arrive. The request goroutines swallow their errors, so a
+// connection refused or an ephemeral-port exhaustion would otherwise leave the
+// counter short and hang until the 10-minute package timeout, taking every
+// other test's result with it.
+func waitOrFail(t *testing.T, wg *sync.WaitGroup, within time.Duration, what string) {
+	t.Helper()
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(within):
+		t.Fatalf("timed out after %s waiting for %s", within, what)
 	}
 }

--- a/internal/proxy/shutdown_unix_test.go
+++ b/internal/proxy/shutdown_unix_test.go
@@ -59,8 +59,9 @@ func TestProxy_ShutdownWaitsForCaptureFromInFlightRequest(t *testing.T) {
 	writeDir := t.TempDir()
 
 	// With dedupe=overwrite the capture path is fully determined: METHOD,
-	// sanitised URL path, status. Put a FIFO there so the write blocks.
-	coatPath := filepath.Join(writeDir, "GET_blocked_200.yaml")
+	// sanitised URL path, status. The FIFO goes where the capture actually
+	// writes -- the temp file it renames from -- so the write blocks there.
+	coatPath := blockingPathFor(writeDir, "GET_blocked_200.yaml")
 	if err := syscall.Mkfifo(coatPath, 0600); err != nil {
 		t.Fatalf("failed to create fifo at %s: %v", coatPath, err)
 	}
@@ -168,7 +169,7 @@ func TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain(t *testing.T) {
 	defer upstream.Close()
 
 	writeDir := t.TempDir()
-	coatPath := filepath.Join(writeDir, "GET_blocked_200.yaml")
+	coatPath := blockingPathFor(writeDir, "GET_blocked_200.yaml")
 	if err := syscall.Mkfifo(coatPath, 0600); err != nil {
 		t.Fatalf("failed to create fifo at %s: %v", coatPath, err)
 	}
@@ -227,6 +228,21 @@ func TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain(t *testing.T) {
 	}
 	waitOrFail(t, &parkedRequest, 30*time.Second, "the parked request to finish")
 
+	// The capture this test deliberately abandoned is now unblocked and about to
+	// rename its temp file into the write directory. Let it finish before the
+	// test returns, or t.TempDir's cleanup races the rename and fails with
+	// "directory not empty".
+	captures := make(chan struct{})
+	go func() {
+		p.WaitCaptures()
+		close(captures)
+	}()
+	select {
+	case <-captures:
+	case <-time.After(30 * time.Second):
+		t.Fatal("timed out waiting for the released capture to finish")
+	}
+
 	if shutdownErr == nil {
 		t.Fatal("expected Shutdown to report the HTTP drain deadline")
 	}
@@ -254,4 +270,14 @@ func waitOrFail(t *testing.T, wg *sync.WaitGroup, within time.Duration, what str
 	case <-time.After(within):
 		t.Fatalf("timed out after %s waiting for %s", within, what)
 	}
+}
+
+// blockingPathFor returns the path a capture for coatName writes before
+// renaming it into place. Placing a FIFO there parks the capture in its write.
+//
+// Captures write to a temp file and rename, so a FIFO at the destination is
+// never opened and cannot block anything -- the block has to sit where the
+// bytes actually go. The name mirrors proxy.tempPathFor.
+func blockingPathFor(dir, coatName string) string {
+	return filepath.Join(dir, "."+coatName+".tmp")
 }

--- a/internal/proxy/shutdown_unix_test.go
+++ b/internal/proxy/shutdown_unix_test.go
@@ -221,11 +221,7 @@ func TestProxy_ShutdownDoesNotDrainCapturesAfterAFailedHTTPDrain(t *testing.T) {
 
 	// Release everything before asserting, so a failure cannot hang the suite.
 	close(parked)
-	fifo, ferr := os.OpenFile(coatPath, os.O_RDONLY, 0)
-	if ferr == nil {
-		_, _ = io.Copy(io.Discard, fifo)
-		_ = fifo.Close()
-	}
+	drainFifo(t, coatPath, 30*time.Second)
 	waitOrFail(t, &parkedRequest, 30*time.Second, "the parked request to finish")
 
 	// The capture this test deliberately abandoned is now unblocked and about to

--- a/internal/server/body_file_unix_test.go
+++ b/internal/server/body_file_unix_test.go
@@ -1,0 +1,168 @@
+//go:build unix
+
+package server_test
+
+import (
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/yesdevnull/trenchcoat/internal/coat"
+	"github.com/yesdevnull/trenchcoat/internal/server"
+)
+
+// body_file resolution is the one place a coat file names a path on disk, so it
+// is the one place a coat can try to read something it should not. The guard
+// has three layers -- reject absolute paths, reject anything outside the coat
+// directory before touching the filesystem, then re-check after resolving
+// symlinks -- and only the first had a test.
+//
+// The symlink layer is the one that has already been wrong once: an earlier
+// version pre-checked with os.Stat, which follows symlinks, so a symlink
+// pointing outside the coat directory was probed before EvalSymlinks ran.
+//
+// What these tests pin is the containment decision itself: delete the
+// post-EvalSymlinks check and the escaping test serves the target file's
+// contents with a 200. They do not pin the Lstat-versus-Stat choice, which
+// swaps clean -- that choice governs whether an out-of-tree path is touched at
+// all, not whether it is ultimately served, so it needs a different kind of
+// test than a status code.
+//
+// Unix-only: creating symlinks on Windows needs a privilege the CI runner for
+// this suite does not have. CI runs on ubuntu-latest.
+
+// serveBodyFileCoat starts a server with a single coat whose body_file is
+// bodyFile, resolved relative to a coat file in dir, and returns the response
+// to GET /body.
+func serveBodyFileCoat(t *testing.T, dir, bodyFile string) *http.Response {
+	t.Helper()
+
+	coats := []coat.LoadedCoat{
+		{
+			FilePath: filepath.Join(dir, "coats.yaml"),
+			Coat: coat.Coat{
+				Name:     "body-file",
+				Request:  coat.Request{Method: "GET", URI: "/body"},
+				Response: &coat.Response{Code: 200, BodyFile: bodyFile},
+			},
+		},
+	}
+
+	srv := server.New(coats, server.Config{
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	addr, err := srv.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get("http://" + addr + "/body")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	t.Cleanup(func() { _ = resp.Body.Close() })
+	return resp
+}
+
+func TestResolveBodyFile_SymlinkEscapingTheCoatDirectoryIsRejected(t *testing.T) {
+	// A symlink is the interesting case precisely because the path passes every
+	// textual check: "leak.json" contains no "..", is relative, and sits inside
+	// the coat directory. Only resolving it reveals it points elsewhere.
+	secretDir := t.TempDir()
+	secret := filepath.Join(secretDir, "secret.json")
+	if err := os.WriteFile(secret, []byte(`{"password":"hunter2"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	coatDir := t.TempDir()
+	if err := os.Symlink(secret, filepath.Join(coatDir, "leak.json")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	resp := serveBodyFileCoat(t, coatDir, "leak.json")
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for a body_file symlinked outside the coat directory, got %d: %s", resp.StatusCode, body)
+	}
+	if strings.Contains(string(body), "hunter2") {
+		t.Fatalf("the response leaked the target file's contents: %s", body)
+	}
+}
+
+func TestResolveBodyFile_SymlinkWithinTheCoatDirectoryIsServed(t *testing.T) {
+	// The escape check must not reject a symlink that stays inside the coat
+	// directory, or the guard would be untestable from a false positive.
+	coatDir := t.TempDir()
+	real := filepath.Join(coatDir, "real.json")
+	if err := os.WriteFile(real, []byte(`{"ok":true}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(real, filepath.Join(coatDir, "alias.json")); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	resp := serveBodyFileCoat(t, coatDir, "alias.json")
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 for a symlink inside the coat directory, got %d: %s", resp.StatusCode, body)
+	}
+	if string(body) != `{"ok":true}` {
+		t.Fatalf("expected the linked file's contents, got %s", body)
+	}
+}
+
+func TestResolveBodyFile_ParentTraversalIsRejected(t *testing.T) {
+	// Validation rejects ".." at load time, but WithCoat/WithCoats do not
+	// validate, so the runtime guard is the only thing standing between a
+	// programmatically supplied coat and the file above the coat directory.
+	outerDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(outerDir, "secret.json"), []byte(`{"password":"hunter2"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+	coatDir := filepath.Join(outerDir, "coats")
+	if err := os.Mkdir(coatDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	resp := serveBodyFileCoat(t, coatDir, "../secret.json")
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for a body_file above the coat directory, got %d: %s", resp.StatusCode, body)
+	}
+	if strings.Contains(string(body), "hunter2") {
+		t.Fatalf("the response leaked the target file's contents: %s", body)
+	}
+}
+
+func TestResolveBodyFile_MissingFileIsReported(t *testing.T) {
+	resp := serveBodyFileCoat(t, t.TempDir(), "absent.json")
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for a missing body_file, got %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if !strings.Contains(string(body), "not found") {
+		t.Fatalf("response should say the body_file was not found, got %s", body)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -216,7 +216,11 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 	} else if result.Coat.Response != nil {
 		resp = *result.Coat.Response
 	} else {
-		s.writeNoMatch(w, r, start, nil)
+		// The coat matched but defines nothing to send. Reporting "no matching
+		// coat" here blames the request for a defect in the coat, and names
+		// nothing, so there is no way to find the culprit. Validation rejects
+		// this, but the programmatic API does not validate.
+		s.writeCoatHasNoResponse(w, r, result.Name, start)
 		return
 	}
 
@@ -321,6 +325,22 @@ func (s *Server) writeSequenceExhausted(w http.ResponseWriter, r *http.Request, 
 		"coat":  coatName,
 	})
 	s.logRequest(r, coatName, http.StatusNotFound, start)
+}
+
+// writeCoatHasNoResponse answers a request that matched a coat defining
+// neither 'response' nor 'responses'. That is a fault in the coat, not in the
+// request, so it is a 500 and it is logged: the name is the only way the author
+// can find which coat to fix.
+func (s *Server) writeCoatHasNoResponse(w http.ResponseWriter, r *http.Request, coatName string, start time.Time) {
+	s.logger.Error("coat has no response defined", "coat", coatName)
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusInternalServerError)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"error": "coat has no response defined",
+		"coat":  coatName,
+	})
+	s.logRequest(r, coatName, http.StatusInternalServerError, start)
 }
 
 func (s *Server) logRequest(r *http.Request, coatName string, status int, start time.Time) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -4,6 +4,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -105,6 +106,15 @@ func (s *Server) Start(addr string) (string, error) {
 
 // StartTLS begins listening with TLS on the configured address.
 func (s *Server) StartTLS(addr, certFile, keyFile string) (string, error) {
+	// Load the key pair before opening the listener. ServeTLS loads it from the
+	// serving goroutine, after startListener has already reported success and
+	// without closing the listener it was handed, which leaves a bound port that
+	// never accepts: the CLI logs "server started (TLS)", then an error nobody
+	// is watching for, and every client hangs until it times out.
+	if _, err := tls.LoadX509KeyPair(certFile, keyFile); err != nil {
+		return "", fmt.Errorf("invalid TLS cert/key pair (%s, %s): %w", certFile, keyFile, err)
+	}
+
 	return s.startListener(addr, true, func(ln net.Listener) error {
 		return s.httpServer.ServeTLS(ln, certFile, keyFile)
 	})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -130,6 +130,11 @@ func (s *Server) startListener(addr string, tls bool, serve func(net.Listener) e
 	go func() {
 		if err := serve(ln); err != nil && !errors.Is(err, http.ErrServerClosed) {
 			s.logger.Error("server error", "error", err, "tls", tls)
+			// Serve failed after startListener reported success, so the caller
+			// is holding an address that will never be answered. Closing the
+			// listener turns a client hang into a connection refused, which is
+			// at least diagnosable.
+			_ = ln.Close()
 		}
 	}()
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -224,7 +224,8 @@ func (s *Server) handleRequest(w http.ResponseWriter, r *http.Request) {
 		// The coat matched but defines nothing to send. Reporting "no matching
 		// coat" here blames the request for a defect in the coat, and names
 		// nothing, so there is no way to find the culprit. Validation rejects
-		// this, but the programmatic API does not validate.
+		// this, and so does WithCoatFile, which loads through LoadPaths -- but
+		// WithCoat and WithCoats take a Coat as given.
 		s.writeCoatHasNoResponse(w, r, result.Name, start)
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -904,3 +904,50 @@ func TestCalls_ReturnsClonedHeaders(t *testing.T) {
 		t.Errorf("expected internal header to remain 'original', got %q", calls2[0].Header.Get("X-Test"))
 	}
 }
+
+func TestServe_CoatWithNoResponse_Returns500(t *testing.T) {
+	// A coat with neither response nor responses matched, was counted as
+	// called, and was then answered with 404 "no matching coat" -- blaming the
+	// request for a defect in the coat, and naming nothing, so even --verbose
+	// could not say which coat was at fault. Only reachable through the
+	// programmatic API, which does not run coat.Validate.
+	var logBuf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
+
+	coats := []coat.LoadedCoat{
+		{
+			Coat: coat.Coat{
+				Name:    "responseless",
+				Request: coat.Request{Method: "GET", URI: "/broken"},
+			},
+		},
+	}
+
+	srv := server.New(coats, server.Config{Logger: logger})
+	addr, err := srv.Start("127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("failed to start server: %v", err)
+	}
+	t.Cleanup(func() { _ = srv.Shutdown(5 * time.Second) })
+
+	resp, err := httpClient.Get("http://" + addr + "/broken")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500 for a coat with no response, got %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("failed to read body: %v", err)
+	}
+	if !strings.Contains(string(body), "responseless") {
+		t.Fatalf("response body should name the offending coat, got: %s", body)
+	}
+	if !strings.Contains(logBuf.String(), "responseless") {
+		t.Fatalf("server should log the offending coat name, got: %s", logBuf.String())
+	}
+}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -202,17 +202,25 @@ func TestServe_DelayMs(t *testing.T) {
 }
 
 func TestServe_DelayJitter(t *testing.T) {
+	// Pins the delay range on both sides. The lower bound alone is satisfied by
+	// the base delay, so it says nothing about jitter; the upper bound is what
+	// stops jitter drifting outside the range the coat asked for.
+	const (
+		base   = 50
+		jitter = 50
+		slack  = 250 * time.Millisecond
+	)
+
 	srv := startServer(t, []coat.LoadedCoat{
 		{
 			Coat: coat.Coat{
 				Name:     "jittery",
 				Request:  coat.Request{Method: "GET", URI: "/jitter"},
-				Response: &coat.Response{Code: 200, Body: "ok", DelayMs: 50, DelayJitterMs: 50},
+				Response: &coat.Response{Code: 200, Body: "ok", DelayMs: base, DelayJitterMs: jitter},
 			},
 		},
 	})
 
-	// Make several requests — all should take at least 50ms (the base delay).
 	for range 3 {
 		start := time.Now()
 		resp, err := httpClient.Get(srv.URL() + "/jitter")
@@ -222,30 +230,65 @@ func TestServe_DelayJitter(t *testing.T) {
 		}
 		_ = resp.Body.Close()
 		assertEqual(t, "status", 200, resp.StatusCode)
-		if elapsed < 50*time.Millisecond {
-			t.Fatalf("expected at least 50ms delay, got %v", elapsed)
+
+		if elapsed < base*time.Millisecond {
+			t.Fatalf("expected at least the %dms base delay, got %v", base, elapsed)
+		}
+		if elapsed > (base+jitter)*time.Millisecond+slack {
+			t.Fatalf("expected at most %dms plus scheduling slack, got %v", base+jitter, elapsed)
 		}
 	}
 }
 
 func TestServe_DelayJitter_OnlyJitter(t *testing.T) {
-	// Jitter without base delay should still work.
+	// Asserting a 200 proves nothing about jitter: deleting rand.IntN from the
+	// delay path leaves such a test green, and delay_jitter_ms becomes a
+	// documented no-op. With no base delay, any delay observed at all can only
+	// have come from the jitter.
+	//
+	// A single draw can legitimately be near zero, so this takes the largest of
+	// several. Ten draws from [0,300) all landing under 30ms has probability
+	// 1e-10; without jitter every request returns in about a millisecond and the
+	// test fails every time.
+	const (
+		jitter    = 300
+		requests  = 10
+		threshold = 30 * time.Millisecond
+	)
+
 	srv := startServer(t, []coat.LoadedCoat{
 		{
 			Coat: coat.Coat{
 				Name:     "jitter-only",
 				Request:  coat.Request{Method: "GET", URI: "/jitter-only"},
-				Response: &coat.Response{Code: 200, Body: "ok", DelayJitterMs: 10},
+				Response: &coat.Response{Code: 200, Body: "ok", DelayJitterMs: jitter},
 			},
 		},
 	})
 
-	resp, err := httpClient.Get(srv.URL() + "/jitter-only")
-	if err != nil {
-		t.Fatalf("request failed: %v", err)
+	var longest time.Duration
+	for range requests {
+		start := time.Now()
+		resp, err := httpClient.Get(srv.URL() + "/jitter-only")
+		elapsed := time.Since(start)
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		_ = resp.Body.Close()
+		assertEqual(t, "status", 200, resp.StatusCode)
+
+		if elapsed > longest {
+			longest = elapsed
+		}
+		if elapsed > jitter*time.Millisecond+250*time.Millisecond {
+			t.Fatalf("delay of %v exceeds the %dms jitter ceiling", elapsed, jitter)
+		}
 	}
-	_ = resp.Body.Close()
-	assertEqual(t, "status", 200, resp.StatusCode)
+
+	if longest < threshold {
+		t.Fatalf("no request was delayed more than %v across %d requests (longest %v); delay_jitter_ms appears to have no effect",
+			threshold, requests, longest)
+	}
 }
 
 func TestServe_GlobMatching(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -208,7 +208,11 @@ func TestServe_DelayJitter(t *testing.T) {
 	const (
 		base   = 50
 		jitter = 50
-		slack  = 250 * time.Millisecond
+		// Generous: this bound exists to catch a delay wildly outside the range
+		// the coat asked for -- milliseconds read as seconds, say -- not to
+		// measure the scheduler. A tight bound here is just a flake under load
+		// or coverage instrumentation.
+		slack = 2 * time.Second
 	)
 
 	srv := startServer(t, []coat.LoadedCoat{
@@ -280,7 +284,7 @@ func TestServe_DelayJitter_OnlyJitter(t *testing.T) {
 		if elapsed > longest {
 			longest = elapsed
 		}
-		if elapsed > jitter*time.Millisecond+250*time.Millisecond {
+		if elapsed > jitter*time.Millisecond+2*time.Second {
 			t.Fatalf("delay of %v exceeds the %dms jitter ceiling", elapsed, jitter)
 		}
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -201,8 +201,8 @@ func TestServe_DelayMs(t *testing.T) {
 	assertEqual(t, "status", 200, resp.StatusCode)
 }
 
-func TestServe_DelayJitter(t *testing.T) {
-	// Pins the delay range on both sides. The lower bound alone is satisfied by
+func TestServe_DelayMsPlusJitter_StaysInRange(t *testing.T) {
+	// Pins the delay range, and nothing more. The lower bound alone is satisfied by
 	// the base delay, so it says nothing about jitter; the upper bound is what
 	// stops jitter drifting outside the range the coat asked for.
 	const (
@@ -953,11 +953,12 @@ func TestCalls_ReturnsClonedHeaders(t *testing.T) {
 }
 
 func TestServe_CoatWithNoResponse_Returns500(t *testing.T) {
-	// A coat with neither response nor responses matched, was counted as
-	// called, and was then answered with 404 "no matching coat" -- blaming the
-	// request for a defect in the coat, and naming nothing, so even --verbose
-	// could not say which coat was at fault. Only reachable through the
-	// programmatic API, which does not run coat.Validate.
+	// A coat with neither response nor responses is a fault in the coat, not a
+	// request that found no match, so it must be a 500 that names the coat --
+	// answering 404 "no matching coat" blames the request and names nothing, so
+	// not even --verbose can identify the culprit. Reachable through
+	// WithCoat/WithCoats, which take a Coat as given; WithCoatFile validates
+	// via LoadPaths.
 	var logBuf bytes.Buffer
 	logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelError}))
 

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -118,10 +118,16 @@ func TestServe_TLS_CorruptKeyFile(t *testing.T) {
 
 func TestStartTLS_InvalidCertPair_ReturnsError(t *testing.T) {
 	// ServeTLS loads the key pair after the listener exists and returns without
-	// closing it, so reporting success here leaves a bound port that never
-	// accepts: `trenchcoat serve --tls-cert bad.pem` logs "server started
-	// (TLS)", then an error from a goroutine, and hangs every client until
+	// closing it, so reporting success here left a bound port that never
+	// accepts: `trenchcoat serve --tls-cert bad.pem` logged "server started
+	// (TLS)", then an error from a goroutine, and hung every client until
 	// timeout while exiting 0 on SIGINT. The caller must be told at start time.
+	//
+	// Loading the pair before opening a listener means no port can be left
+	// bound on this path at all, so there is nothing separate to assert about
+	// that -- a companion test probing the port only ever re-tested the error
+	// below. Serve failures from other causes still leak a listener; that is
+	// handled in startListener rather than here.
 	dir := t.TempDir()
 	certFile := filepath.Join(dir, "bad-cert.pem")
 	keyFile := filepath.Join(dir, "bad-key.pem")
@@ -141,44 +147,6 @@ func TestStartTLS_InvalidCertPair_ReturnsError(t *testing.T) {
 	if !strings.Contains(err.Error(), "TLS") && !strings.Contains(err.Error(), "tls") {
 		t.Fatalf("error should name the TLS cert/key pair as the cause, got: %v", err)
 	}
-}
-
-func TestStartTLS_InvalidCertPair_DoesNotLeaveAPortBound(t *testing.T) {
-	// The failed listener must be closed, not leaked: a bound port that never
-	// accepts is worse than a clean failure, and on a fixed --port it also
-	// blocks the retry after fixing the certificate.
-	dir := t.TempDir()
-	certFile := filepath.Join(dir, "bad-cert.pem")
-	keyFile := filepath.Join(dir, "bad-key.pem")
-	if err := os.WriteFile(certFile, []byte("not a certificate"), 0600); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(keyFile, []byte("not a key"), 0600); err != nil {
-		t.Fatal(err)
-	}
-
-	// Claim a port, note it, release it, then make the server fail on it.
-	probe, err := net.Listen("tcp4", "127.0.0.1:0")
-	if err != nil {
-		t.Fatal(err)
-	}
-	addr := probe.Addr().String()
-	if err := probe.Close(); err != nil {
-		t.Fatal(err)
-	}
-
-	srv := server.New(nil, server.Config{})
-	if _, err := srv.StartTLS(addr, certFile, keyFile); err == nil {
-		t.Cleanup(func() { _ = srv.Shutdown(5 * time.Second) })
-		t.Fatal("StartTLS reported success on an invalid cert/key pair")
-	}
-
-	// The port must be free again.
-	again, err := net.Listen("tcp4", addr)
-	if err != nil {
-		t.Fatalf("port %s still bound after StartTLS failed: %v", addr, err)
-	}
-	_ = again.Close()
 }
 
 func TestServe_TLS_MismatchedCertAndKey(t *testing.T) {

--- a/internal/server/tls_test.go
+++ b/internal/server/tls_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -113,6 +114,71 @@ func TestServe_TLS_CorruptKeyFile(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected TLS handshake error with corrupt key, but request succeeded")
 	}
+}
+
+func TestStartTLS_InvalidCertPair_ReturnsError(t *testing.T) {
+	// ServeTLS loads the key pair after the listener exists and returns without
+	// closing it, so reporting success here leaves a bound port that never
+	// accepts: `trenchcoat serve --tls-cert bad.pem` logs "server started
+	// (TLS)", then an error from a goroutine, and hangs every client until
+	// timeout while exiting 0 on SIGINT. The caller must be told at start time.
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "bad-cert.pem")
+	keyFile := filepath.Join(dir, "bad-key.pem")
+	if err := os.WriteFile(certFile, []byte("not a certificate"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("not a key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := server.New(nil, server.Config{})
+	addr, err := srv.StartTLS("127.0.0.1:0", certFile, keyFile)
+	if err == nil {
+		t.Cleanup(func() { _ = srv.Shutdown(5 * time.Second) })
+		t.Fatalf("StartTLS reported success on an invalid cert/key pair, listening at %s", addr)
+	}
+	if !strings.Contains(err.Error(), "TLS") && !strings.Contains(err.Error(), "tls") {
+		t.Fatalf("error should name the TLS cert/key pair as the cause, got: %v", err)
+	}
+}
+
+func TestStartTLS_InvalidCertPair_DoesNotLeaveAPortBound(t *testing.T) {
+	// The failed listener must be closed, not leaked: a bound port that never
+	// accepts is worse than a clean failure, and on a fixed --port it also
+	// blocks the retry after fixing the certificate.
+	dir := t.TempDir()
+	certFile := filepath.Join(dir, "bad-cert.pem")
+	keyFile := filepath.Join(dir, "bad-key.pem")
+	if err := os.WriteFile(certFile, []byte("not a certificate"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyFile, []byte("not a key"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Claim a port, note it, release it, then make the server fail on it.
+	probe, err := net.Listen("tcp4", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := probe.Addr().String()
+	if err := probe.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	srv := server.New(nil, server.Config{})
+	if _, err := srv.StartTLS(addr, certFile, keyFile); err == nil {
+		t.Cleanup(func() { _ = srv.Shutdown(5 * time.Second) })
+		t.Fatal("StartTLS reported success on an invalid cert/key pair")
+	}
+
+	// The port must be free again.
+	again, err := net.Listen("tcp4", addr)
+	if err != nil {
+		t.Fatalf("port %s still bound after StartTLS failed: %v", addr, err)
+	}
+	_ = again.Close()
 }
 
 func TestServe_TLS_MismatchedCertAndKey(t *testing.T) {

--- a/trenchcoat_test.go
+++ b/trenchcoat_test.go
@@ -485,3 +485,104 @@ coats:
 		t.Fatal("expected validation errors for coat without URI")
 	}
 }
+
+func TestServer_ResetCallsAndStringPtrBodyMatching(t *testing.T) {
+	// The assertion helpers are the advertised reason to use this package from a
+	// Go test, and ResetCalls in particular is what makes a server reusable
+	// across subtests. StringPtr exists because Request.Body is a *string, so an
+	// empty body constraint can be told apart from no constraint at all -- this
+	// exercises both together, since a body-constrained coat is where StringPtr
+	// is actually needed.
+	srv := NewServer(
+		WithCoat(Coat{
+			Name: "create-user",
+			Request: Request{
+				Method: "POST",
+				URI:    "/api/users",
+				Body:   StringPtr(`{"name":"alice"}`),
+			},
+			Response: &Response{Code: 201, Body: `{"id":1}`},
+		}),
+	)
+	srv.Start(t)
+
+	post := func(body string) int {
+		t.Helper()
+		resp, err := http.Post(srv.URL+"/api/users", "application/json", strings.NewReader(body))
+		if err != nil {
+			t.Fatalf("request failed: %v", err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return resp.StatusCode
+	}
+
+	// The body constraint must actually constrain: a different body is no match.
+	if got := post(`{"name":"bob"}`); got != http.StatusNotFound {
+		t.Fatalf("expected 404 for a body the coat does not constrain to, got %d", got)
+	}
+	srv.AssertNotCalled(t, "create-user")
+
+	if got := post(`{"name":"alice"}`); got != http.StatusCreated {
+		t.Fatalf("expected 201 for the constrained body, got %d", got)
+	}
+	if got := post(`{"name":"alice"}`); got != http.StatusCreated {
+		t.Fatalf("expected 201 on the second call, got %d", got)
+	}
+	srv.AssertCalledN(t, "create-user", 2)
+
+	if reqs := srv.Requests("create-user"); len(reqs) != 2 {
+		t.Fatalf("expected 2 recorded requests, got %d", len(reqs))
+	} else if reqs[0].Body != `{"name":"alice"}` {
+		t.Fatalf("recorded request body should be the matched body, got %q", reqs[0].Body)
+	}
+
+	// ResetCalls must clear the record without disturbing the coats, so the same
+	// server can be reused by the next subtest.
+	srv.ResetCalls()
+	srv.AssertNotCalled(t, "create-user")
+	if reqs := srv.Requests("create-user"); len(reqs) != 0 {
+		t.Fatalf("expected no recorded requests after ResetCalls, got %d", len(reqs))
+	}
+
+	if got := post(`{"name":"alice"}`); got != http.StatusCreated {
+		t.Fatalf("server should still serve after ResetCalls, got %d", got)
+	}
+	srv.AssertCalledN(t, "create-user", 1)
+}
+
+func TestServer_StringPtrDistinguishesEmptyBodyFromNoConstraint(t *testing.T) {
+	// The whole reason Request.Body is a pointer: an empty string is a real
+	// constraint ("this request must have no body"), which a plain string could
+	// not express.
+	srv := NewServer(
+		WithCoat(Coat{
+			Name: "empty-body-only",
+			Request: Request{
+				Method: "POST",
+				URI:    "/ping",
+				Body:   StringPtr(""),
+			},
+			Response: &Response{Code: 204},
+		}),
+	)
+	srv.Start(t)
+
+	resp, err := http.Post(srv.URL+"/ping", "text/plain", strings.NewReader(""))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected 204 for an empty body, got %d", resp.StatusCode)
+	}
+
+	resp2, err := http.Post(srv.URL+"/ping", "text/plain", strings.NewReader("payload"))
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	_ = resp2.Body.Close()
+	if resp2.StatusCode != http.StatusNotFound {
+		t.Fatalf("a coat constrained to an empty body must not match a request with one, got %d", resp2.StatusCode)
+	}
+}


### PR DESCRIPTION
Fixes from a full-repo review of `main` at `4795ac2` — quality, security and sanity across all eight packages. Seven reviewers ran in parallel by dimension, every finding was then handed to an adversarial verifier told to refute it, and what survived is below. 31 raw findings became 27 after deduplication, 13 survived verification, 5 were refuted, and 9 fell past the verification cap — those nine were examined in a second pass, covered further down.

Every fix here started as a failing test. Where a test could not be made to fail, that is said plainly rather than papered over — three findings ended that way, and two of them changed the outcome.

## The one worth reading first

**Captured coats kept the upstream `Content-Length` after the proxy rewrote the body.** The header filter dropped it only on the gzip path, so `--pretty-json` wrote a coat whose recorded length described the *upstream* body, not the pretty-printed one on disk. Replaying that coat makes `net/http` return `ErrContentLength` and write zero bytes: the client gets `200 OK`, the stale length, and `unexpected EOF`. An advertised flag was producing fixtures that could not be replayed. `Content-Length` is now never recorded — the captured body is what the mock serves, and `net/http` derives the length itself.

## Behaviour changes worth a second look

**Header, query and `body_match: glob` patterns no longer stop at `/`.** They were matched with `path.Match`, so `Content-Type: "*"` did not match `application/json`, `redirect: "*"` did not match `/home/dash`, and `{"url": "*"}` did not match a body containing a URL — the server 404'd on configurations CLAUDE.md documents as valid, silently. They now compile to an anchored regexp where `*` is any sequence and `?` any single character.

Per Dan's call, this drops `path.Match`'s undocumented `[a-z]` character classes for these three fields. Only `*` and `?` were ever documented, and the classes were also the source of a silent failure: `path.Match` returns `ErrBadPattern` for an unclosed `[`, the error was discarded, and such a pattern could never match anything. URI globbing is untouched and stays segment-aware via `doublestar`.

**Regex URIs are now anchored as a group.** `"^" + pattern + "$"` on a top-level alternation gives `"^/users|/accounts$"`, which reads as `(^/users)|(/accounts$)` — so `~/users|/accounts` also matched `/users/secret/1` and `/x/y/accounts`. Both the matcher and the validator built that string by hand; they now share `coat.AnchorRegexURI` so they cannot drift.

**`StartTLS` now fails on a bad cert/key pair** instead of reporting success and leaving a bound port that never accepts. The public API already did this, with a comment explaining why; the CLI path was the inconsistency.

## Also fixed

- **Shutdown lost captures for in-flight requests.** The capture drain ran before the HTTP drain, so requests still in flight registered their captures after the wait had already returned — Ctrl-C mid-request silently discarded exactly the coat files being recorded. The drains are inverted, and capture registration now happens before the response is relayed.
- **`dedupe=skip` could write two files for one request.** Filename selection and the write were not atomic, so concurrent captures all saw an empty directory; those landing either side of a second boundary wrote separate files.
- **Glob URIs that cannot compile are rejected at validation** rather than sitting dead in the file. `/api/items[]` previously produced the diagnostic `pattern "/api/items[]" did not match "/api/items[]"` — a string apparently not matching itself.
- **An unrecognised `sequence` value no longer panics the server** by indexing past `Responses`, and a coat with no response returns a 500 naming the coat rather than 404 "no matching coat", which blamed the request for a defect in the coat.
- **The proxy forwards the client's path as written**, instead of decoding `%2F` in transit and relaying a request to a different route than the one asked for.

## Test-quality work

`validateResponse` had **zero** coverage on every one of its six error branches: replacing the whole function with `return nil` left all nine packages green. Two of those rules have no runtime backstop — the server sizes its write timeout assuming `delay_ms` is capped, and calls `rand.IntN` on the jitter, which panics on a negative value. There is now a table covering all six across both the `response` and `responses[N]` prefixes; with the function stubbed, those twelve subtests are the only failures in the repo.

`TestMatch_BodyExceedsMaxSize_NoMatch` passed for the wrong reason: it constrained the coat body to `"test"` while sending 1 MiB+1 of `"x"`, so the non-match was a content mismatch and had nothing to do with the size cap it named. Deleting the truncation branch left it green. It now sends the same oversized string it constrains.

## Three findings that did not survive contact

Reported honestly rather than quietly dropped:

1. **A `WaitCaptures` test I wrote caught nothing.** Moving the capture registration back after the response write and running it 50 times passed every time. It was deleted. The reordering is still correct and still landed, but it ships without a regression test rather than with a decorative one.
2. **The torn-capture-file theory is wrong.** `os.WriteFile` issues a single `write` syscall and the kernel serialises writes to a regular file, so 40 rounds of two concurrent 200 KiB captures and 16 simultaneous 512 KiB captures all produced intact, parseable coats. No lock was added for that. The tests stay, because the invariant is worth pinning if the write is ever chunked.
3. **I was wrong about `dedupe=skip`, and said so in the history.** I concluded the missing lock could not produce extra files because the filename carries a one-second timestamp. The test then caught two files a second apart under `-race`. `c6bc15c` fixes the bug and corrects the earlier claim explicitly.

The shutdown test also went through three timing-based versions that caught the bug 7 times in 12, then 0 in 12 after a retune. Tuning payload sizes against `http.Server.Shutdown`'s backing-off poll interval produces a coin toss, not a regression test. It is now deterministic: a FIFO sits where the capture will write, so `os.WriteFile` parks there, and the correct ordering must spend its whole capture-drain budget while the broken one returns as soon as connections are idle — a difference of a second, not microseconds. 8 failures out of 8 against the old ordering, 5 passes out of 5 against the new, each at a flat 1.02s. It needs `mkfifo`, so it is unix-only behind a build tag; CI runs the suite on `ubuntu-latest`.

## Third pass: a four-agent review of this branch

Reviewed by four specialised agents (general quality, test quality, error handling, comment accuracy). They found **four defects introduced by earlier commits on this branch**, two of which were reproduced independently by two agents each.

**Concurrent captures could tear a coat file, and the default dedupe mode was the unprotected one.** `reserveFilename` records `inflight`, but only the `skip` branch consults it — `overwrite`, the default, gives every capture of a request the same stable name, and the base excludes the query string. `os.WriteFile` is `open(O_TRUNC)` then write with nothing pairing the two, so two writers can interleave and leave one response's bytes over the head of another's. An isolated probe tears **18% of the time** (900/5000). I had asserted in `c6bc15c` that this was impossible because a single write syscall made it safe; that reasoning ignored the truncate. Writes to a given base are now serialised.

**Strict JSON parsing was looser than the `json.Unmarshal` it replaced.** `Decode` reads one value and stops, so trailing garbage, a second appended document and an empty file all loaded silently — reopening one level up the exact hole `4908489` set out to close.

**Captured coats recorded headers that never crossed the wire.** The relay withholds hop-by-hop and `Connection`-scoped headers in both directions; the capture path applied neither to responses and no `Connection` filtering to requests. A client's `Connection: keep-alive, X-Trace-Token` wrote `X-Trace-Token` into the coat as a replay match constraint for a header the upstream never saw, and an upstream's `Connection: close` was recorded and then served by the mock, dropping keep-alive for every replay client. My doc comment claimed the filter covered connection-scoped headers; it never called the function that computes them.

Also fixed: `dedupe=skip` silently degrading to overwrite when `--write-dir` contains a `[`; a body-file failure leaving a coat pointing at another capture's body; `--filter` validated per-request instead of at startup; `Shutdown` panicking after a failed `Start`; load failures logged at `Warn` under a cheerful "coats loaded" line; the glob cache growing across every hot reload; and strict decoding having broken the YAML anchor-holder idiom (top-level `x-` keys are allowed again).

**I invented a technical detail in CLAUDE.md.** "Quote or avoid `[` in exact URIs" — doublestar has no quoting mechanism and YAML quoting does nothing. The escape is a backslash, and even escaped the URI is still matched as a glob; there is no way to make a bracketed URI exact. Corrected, along with an "Add concurrent with Wait panics" over-claim in three places, "the programmatic API does not validate" (`WithCoatFile` does), and a dead `Host` entry whose rationale described something `net/http` prevents.

## Tests added

Chosen by where a gap would hurt, not by percentage. 87.3% → 88.4%.

**`body_file` containment had one test, for absolute paths.** It is the only place a coat names a path on disk, its guard has three layers, and the symlink layer has already been wrong once (an earlier fix swapped `os.Stat` for `os.Lstat`). Four tests now cover a symlink escaping the coat directory, a symlink staying inside it, parent traversal, and a missing file. Delete the post-`EvalSymlinks` containment check and the escaping test serves `{"password":"hunter2"}` with a **200**. They pin the containment decision, not the `Lstat`/`Stat` choice, which swaps clean — the comment says so.

**`CallCount`, `ResetCalls` and `StringPtr` were at 0%** despite being the documented way to use this package from a Go test.

**Near-miss diagnostics were at 33%** — the text a user reads when a request they expected to match 404s. Six cases now cover every reason the diagnose functions can give.

**The review round's own fixes had no tests.** Four added, three verified by mutation. The first version of the `--write-dir` glob test was vacuous — stable skip filenames mean a degraded skip still leaves one file, so counting files could not discriminate. It asserts on content instead and fails against the old code.

## CI coverage of the test suite

The workflow runs `go test -v -count=1 -race ./...` on `ubuntu-latest` with no `-short`, so the two short-mode skips never apply. The three `//go:build unix` files do execute there — confirmed by grepping the last CI log for their test names rather than assuming the tag resolves. That run reported **336 passes, 0 failures, 0 skips**.

One real gap found and closed: `TestBinary_ProxyThenServe` — the full round trip through the real binary — proxies to a third-party API and `t.Skipf`s when it is unreachable. A skip is invisible in a green run, so that path could vanish from CI without anything turning red. A sibling now runs the identical round trip against a local upstream, unconditionally; the third-party test stays, so its absence is merely no longer silent. The sibling replays with a different `User-Agent`, which pins the header-capture fix end to end: empty `clientSpecificRequestHeaders` and it returns 404.

## Fourth pass: peer adversarial review

Two independent reviewers went over the whole branch competitively, scored on legitimate findings with bogus or inflated ones disqualifying. Nine issues survived adjudication; **four were raised by both reviewers independently**, which is the strongest signal in the set. All nine are now fixed and re-verified.

**Two majors, both defects this branch introduced.**

*YAML accepted multi-document files and trailing garbage.* The strict-parsing commit added a `dec.More()` check to JSON and left YAML — the primary coat format — reading one document and stopping. A `---`-separated file silently loaded half its coats; `--- }{ invalid` after a valid document was accepted without a word. Both formats now reject content after the first document, while a trailing `---` or `...` marker still parses.

*A capture published the coat before the `body_file` it referenced.* Between the two writes the directory held a valid-looking coat naming a file that did not exist, which `serve --watch` reloads and answers with a 500 — and if the process died in that window the broken coat was permanent, unrecoverable under `--dedupe skip`. The code comment justified the ordering with a hazard that cannot occur: `bodyFileName` is derived from `filename`, so an orphan body is overwritten by the next capture of the same request, never mispaired.

Note both reviewers recommended simply reverting to body-first — that reintroduces the mispairing an *earlier* review round caught. The fix stages both files as temps and renames the body into place first, so the coat's rename is the single commit point and a coat never appears before its target.

**Also fixed:** `baseLocks` accumulated a mutex per distinct `METHOD_path_status` for the life of the process, where the neighbouring `inflight` map was carefully reaped; hot-reload failures still logged at `Warn` after startup failures were promoted to `Error`; a near-miss diagnostic test asserted on `"page"`, which the *other* query branch also emits, so deleting the branch under test left it green; and the proxy could emit a coat its own validator rejects, because a captured path containing a bracket is recorded verbatim and then read as a glob (`/items[abc]` matches `/itemsa`, never the path it was captured from).

**The `x-` extension key is gone entirely.** It was added a few commits earlier on this branch to preserve a YAML idiom that strict parsing had broken — a top-level key holding an anchor for coats to merge in. It turned out YAML already supports that without any extension key: anchor on a real field of the first coat and merge with `<<:` from the rest. Verified end to end, including overriding a merged field. So the feature enabled something that already worked, and it forced an unresolvable documentation problem — one JSON Schema covers both formats, the parser allowed `x-` only in YAML, and JSON Schema cannot tell the formats apart, so the schema was wrong in one direction whichever way it was written. Removing it makes a single strict schema correct for both. CLAUDE.md documents the inline-anchor pattern in its place.

**One decision recorded rather than assumed:** `Accept` and `Accept-Language` stay out of captures, so captures remain portable across clients. The cost is that a content-negotiating upstream collapses onto one coat — capture `/doc` as JSON then as XML and the surviving coat holds XML with no `Accept` constraint. That limitation is now documented under Proxy Capture.

## Verification

`gofmt -l`, `goimports -l`, `go vet ./...`, `golangci-lint run ./...` (0 issues) and `go test -race -count=1 ./...` (9/9 packages) all clean. Coverage 88.9% of statements. Each fix was additionally confirmed by mutation — reverting the production change and watching the new test fail — and every such check is recorded in the relevant commit message.

## Second pass: the nine deferred findings

All nine have now been examined. Seven were real and are fixed; two were handled differently and are explained below.

**The worst bug in the whole review turned up here.** Every request header a coat records becomes a match constraint at replay, and the capture path recorded everything not in `--strip-headers` (default: just `Authorization`, `Cookie`, `Set-Cookie`). So a capture taken with curl carried `User-Agent: curl/8.7.1`, `Accept: */*` and `Accept-Encoding: gzip`, and replaying the identical request from any other client returned **404**. Verified end to end before and after. Proxy capture was largely unusable for its stated purpose. Client- and connection-specific headers are no longer captured; `Content-Type` and custom headers such as `X-Api-Key` still are.

**Coat files silently ignored unknown fields.** `coatfile.schema.json` sets `additionalProperties: false` throughout, but the parsers discarded unknown keys, so `mehtod: POST` passed `trenchcoat validate` with exit 0 and then served GET — the POSTs it was written for 404'd while unintended GETs matched. Both decoders are now strict, and the CLI reports the field and line.

Also fixed: a character class was counted as literal prefix, so `/api/[ij]tems/detail` scored 20 against `/api/items/*` at 11 and won a path it was less specific for; and headers a peer scopes to one hop via `Connection` were forwarded in both directions, contrary to RFC 9110 §7.6.1.

**Three more false-confidence tests**, all verified by mutation:

- Both delay-jitter tests passed with jitter deleted — one asserted only the base delay, the other only a 200 status. `delay_jitter_ms` was documented with no coverage whatsoever. The jitter-only test now takes the longest of ten draws from a 300 ms jitter and requires it to exceed 30 ms; against jitter removal the longest observed is ~600 µs.
- `TestProxyCapturesConcurrencyBounded` asserted `len(files) >= 20` for 30 requests, so a third could vanish and it would still pass — and deleting `captureSem` entirely left it green. The count is now exact, and a new test blocks the first 20 captures on FIFOs so captures beyond the bound provably cannot run.
- `TestProxyShutdownRespectsTimeoutWithPendingCaptures` never had a pending capture; it is deleted, superseded by the FIFO-based shutdown test.

**Writing that concurrency test caught an overreach in my own earlier commit.** Making filename selection and the write atomic (`c6bc15c`) held `p.mu` across the file I/O, so captures became fully serial and `captureSem`'s bound of 20 was unreachable — one slow write stalled every other capture. I had called that "acceptable" in the commit message; it was not. The lock now covers only the decision, with an in-flight set so `dedupe=skip` still yields one file per request while unrelated captures run concurrently.

**One finding I declined.** `captureSem` is acquired inside the capture goroutine, so a burst queues goroutines each holding up to 10 MiB of buffers. Moving the acquire into the handler would bound that memory, but at the cost of blocking the proxied request on capture I/O — a stalled `--write-dir` would then stall the proxying itself, which is the one thing a transparent proxy must not do. The misleading comment claiming it bounds "concurrent capture goroutines" is corrected to say what it actually bounds and why.

**A flake I introduced, caught and fixed.** One full-suite run under coverage failed and did not reproduce in eight further runs. The tight upper bounds I had just added to the jitter tests are the likely cause; they exist to catch a delay wildly outside the coat's range, not to measure the scheduler, so they now allow 2 s of slack. The assertion doing the real work is unaffected.

## Not examined

The reviewers also did not cover `internal/config`, `cmd/trenchcoat/main.go` signal handling, `cmd/trenchcoat/validate.go`, or hot-reload/fsnotify behaviour in `serve.go`, and did not diff `coatfile.schema.json` against `internal/coat/types.go` field by field. `govulncheck` was not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z3nWoaTWaYM2R1wpsMEFL
