### PR TITLE
release: mark prereleases, and publish via a draft for immutability

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,3 +62,18 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # .goreleaser.yaml builds the release as a draft so every archive is
+      # attached before anyone can see it. Publishing is the separate step,
+      # because with release immutability enabled a published release has its
+      # assets and its git tag locked — an upload arriving afterwards has
+      # nothing to attach to.
+      #
+      # If this step fails the draft survives, holding every artefact, and can
+      # be published by hand. That is the outcome worth having: an unpublished
+      # complete release rather than a published incomplete one.
+      - name: Publish the draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.ref_name }}
+        run: gh release edit "$TAG" --draft=false

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,8 +42,11 @@ release:
   # publishes as an ordinary release and takes GitHub's "Latest" badge — an
   # alpha handed to everyone who lands on the repository as the current stable
   # version. The workflow reports success either way, so nothing catches it.
-  # "auto" reads the semver prerelease suffix and marks -alpha, -beta and -rc
-  # accordingly.
+  # "auto" marks the release as a prerelease when the tag carries a prerelease
+  # indicator — v1.0.0-alpha.1, v1.0.0-rc1 and so on. GoReleaser documents the
+  # rule only as "in case there is an indicator for this in the tag", without
+  # saying what counts, so an unusual suffix is worth checking on the release
+  # itself rather than assuming.
   prerelease: auto
 
   # Publish as a draft and let the workflow flip it live once every archive is

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -45,3 +45,15 @@ release:
   # "auto" reads the semver prerelease suffix and marks -alpha, -beta and -rc
   # accordingly.
   prerelease: auto
+
+  # Publish as a draft and let the workflow flip it live once every archive is
+  # attached. This is GitHub's prescribed order for immutable releases: assets
+  # and the git tag are locked the moment a release is published, so anything
+  # uploaded afterwards has to fight the lock. Creating the release complete
+  # and then publishing it means there is never an incomplete published
+  # release to repair.
+  #
+  # It is also the safer failure mode without immutability: a run that dies
+  # midway leaves an unpublished draft rather than a live release missing half
+  # its binaries.
+  draft: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -36,3 +36,12 @@ changelog:
     exclude:
       - "^docs:"
       - "^test:"
+
+release:
+  # GoReleaser defaults this to false, so without it a tag like v1.0.0-alpha.1
+  # publishes as an ordinary release and takes GitHub's "Latest" badge — an
+  # alpha handed to everyone who lands on the repository as the current stable
+  # version. The workflow reports success either way, so nothing catches it.
+  # "auto" reads the semver prerelease suffix and marks -alpha, -beta and -rc
+  # accordingly.
+  prerelease: auto


### PR DESCRIPTION
Two release-publishing fixes, both prompted by `v1.0.0-alpha.1`.

## The alpha published as the latest stable release

GoReleaser defaults `release.prerelease` to `false`, so `v1.0.0-alpha.1` went out as an ordinary release and took GitHub's "Latest" badge — an alpha presented as the current stable version to anyone landing on the repository. The release workflow reported success, because from its point of view nothing had gone wrong, which is what makes this worth fixing in config rather than remembering.

That release has been corrected by hand. `prerelease: auto` reads the semver prerelease suffix, so the next `-beta` or `-rc` is marked without anyone having to notice.

## Preparing for immutable releases

GitHub's immutable releases lock a release's assets **and its git tag** the moment it is published. This workflow published first and uploaded into the live release, which is precisely the order that has to fight the lock.

GoReleaser now builds the release as a draft with every archive attached, and a separate step publishes it — the order GitHub prescribes:

> Create the release as a draft. Attach all associated assets to the draft release. Publish the draft release.

This is the better failure mode either way. A run that dies partway now leaves an unpublished draft holding whatever it built, rather than a published release missing half its binaries — and a draft can be finished by hand, where a published immutable release cannot.

Note that immutability itself is **not** enabled by this PR. It has no REST API — `PATCH /repos/{owner}/{repo}` with `immutable_releases` is silently ignored — so it has to be switched on in **Settings → Releases → Enable release immutability**. These changes are safe to land before or after that, and are worth having regardless.

## Verification

`goreleaser check` passes and `actionlint` is clean. The tag reaches the shell through `env:` rather than inline expansion, matching the other workflows.

Three things config cannot prove, all observable at the next tag and worth a glance then:

- `prerelease: auto` marking a `-rc`/`-beta` tag — accepted by `goreleaser check`, but the behaviour only shows on a real prerelease.
- `gh release edit --draft=false` preserving the prerelease flag GoReleaser set. It sends only the fields named, so it should.
- A draft release being addressable by tag name. The tag exists before the workflow runs, so it should.

The changelog is deliberately untouched. The first release's spanned the entire history only because there was no previous tag to diff against; subsequent tags diff from their predecessor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136bDtWBAdKtufTHcXoSwQK
